### PR TITLE
Release 0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.2.1 (2026-02-05)
+
+### Fixed
+- Return HTTP 429 `rate_limit` error when max pending pairing requests (3) is reached, instead of returning an empty pairing code
+
 ## 0.2.0 (2026-02-04)
 
 ### Added
@@ -13,7 +18,7 @@
 
 ### Security
 - Device tokens are HMAC-signed and do not expose the gateway's master secret
-- Pending pairing requests expire after 10 minutes (max 3 per channel)
+- Pending pairing requests expire after 1 hour (max 3 per channel)
 - Each device requires explicit approval by the gateway owner
 
 ## 0.1.1 (2026-02-03)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contextableai/clawg-ui",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "AG-UI protocol channel plugin for OpenClaw — connect CopilotKit and AG-UI clients to your OpenClaw gateway",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- Return HTTP 429 `rate_limit` error when max pending pairing requests (3) is reached
- Fix changelog: pending requests expire after 1 hour (not 10 minutes)

## Test plan
- [x] Unit test added for rate limit scenario
- [x] Manual verification against running gateway

🤖 Generated with [Claude Code](https://claude.com/claude-code)