### PR TITLE
fix: use standard git+https format for repository URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/contextable/clawg-ui"
+    "url": "git+https://github.com/contextable/clawg-ui.git"
   },
   "keywords": [
     "openclaw",


### PR DESCRIPTION
## Summary
- Updates repository URL to standard `git+https://...git` format for npm compatibility

## Test plan
- [ ] Verify npm publish works after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)