### PR TITLE
Split tool and text events into separate AG-UI runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.2.4 (2026-02-06)
+
+### Changed
+- Separate tool call events and text message events into distinct AG-UI runs — when text follows a tool call, the tool run is finished and a new run (with a unique runId) is started for the text messages
+
 ## 0.2.3 (2026-02-06)
 
 ### Fixed

--- a/index.ts
+++ b/index.ts
@@ -13,6 +13,7 @@ import {
   popToolCallId,
   isClientTool,
   setClientToolCalled,
+  setToolFiredInRun,
 } from "./src/tool-store.js";
 
 const plugin = {
@@ -50,6 +51,7 @@ const plugin = {
         toolCallId,
         toolCallName: event.toolName,
       });
+      setToolFiredInRun(sk);
       if (event.params && Object.keys(event.params).length > 0) {
         console.log(`[clawg-ui] before_tool_call: emitting TOOL_CALL_ARGS, params=${JSON.stringify(event.params)}`);
         writer({

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contextableai/clawg-ui",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "AG-UI protocol channel plugin for OpenClaw — connect CopilotKit and AG-UI clients to your OpenClaw gateway",
   "type": "module",
   "license": "MIT",

--- a/src/tool-store.ts
+++ b/src/tool-store.ts
@@ -108,6 +108,26 @@ export function clearClientToolNames(sessionKey: string): void {
   clientToolNames.delete(sessionKey);
 }
 
+// --- Tool-fired-in-run flag ---
+// Tracks whether any tool call (server or client) was emitted in the current
+// run. When a text message is about to be emitted and this flag is set, the
+// http-handler splits into a new run so tool events and text events live in
+// separate runs (per AG-UI protocol best practice).
+
+const toolFiredInRunFlags = new Map<string, boolean>();
+
+export function setToolFiredInRun(sessionKey: string): void {
+  toolFiredInRunFlags.set(sessionKey, true);
+}
+
+export function wasToolFiredInRun(sessionKey: string): boolean {
+  return toolFiredInRunFlags.get(sessionKey) ?? false;
+}
+
+export function clearToolFiredInRun(sessionKey: string): void {
+  toolFiredInRunFlags.delete(sessionKey);
+}
+
 // --- Client-tool-called flag ---
 // Set when a client tool is invoked during a run so the dispatcher can
 // suppress text output and end the run after the tool call events.


### PR DESCRIPTION
## Summary
- When a tool call fires and is followed by text messages, the tool run is finished (`RUN_FINISHED`) and a new run (`RUN_STARTED` with a unique `runId`) is started for the text output
- Adds `toolFiredInRun` per-session flag to `tool-store.ts`, set by the `before_tool_call` hook
- `splitRunIfToolFired()` in `http-handler.ts` checks the flag before emitting text and splits the run if needed
- Text-only responses (no preceding tool call) are unchanged — single run as before

## Test plan
- [x] New test: "splits into a new run when text follows a tool call" — verifies two `RUN_STARTED`/`RUN_FINISHED` pairs with correct runId sequencing
- [x] New test: "does not split run when no tool was called before text" — verifies single run behavior is preserved
- [x] All 27 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)