### PR TITLE
fix: close open text messages before RUN_FINISHED

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.2.7 (2026-02-18)
+
+### Fixed
+- Close open text messages before emitting `RUN_FINISHED` in `splitRunIfToolFired()` — fixes `AGUIError: Cannot send 'RUN_FINISHED' while text messages are still active` when text streaming is followed by a server-side tool call and then more text
+
 ## 0.2.6 (2026-02-10)
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contextableai/clawg-ui",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "AG-UI protocol channel plugin for OpenClaw — connect CopilotKit and AG-UI clients to your OpenClaw gateway",
   "type": "module",
   "license": "MIT",

--- a/src/http-handler.ts
+++ b/src/http-handler.ts
@@ -380,6 +380,15 @@ export function createAguiHttpHandler(api: OpenClawPluginApi) {
       if (!wasToolFiredInRun(sessionKey)) {
         return;
       }
+      // Close any open text message before ending the run
+      if (messageStarted) {
+        writeEvent({
+          type: EventType.TEXT_MESSAGE_END,
+          messageId: currentMessageId,
+          runId: currentRunId,
+        });
+        messageStarted = false;
+      }
       // End the tool run
       writeEvent({
         type: EventType.RUN_FINISHED,


### PR DESCRIPTION
## Summary
- Fixes AG-UI protocol violation: `AGUIError: Cannot send 'RUN_FINISHED' while text messages are still active`
- Adds guard in `splitRunIfToolFired()` to emit `TEXT_MESSAGE_END` before `RUN_FINISHED` if a text message is open

## Problem
When an agent emitted text → called a server-side tool → emitted more text, the `splitRunIfToolFired()` function would send `RUN_FINISHED` to end the tool run without first closing any open text message. This caused the AG-UI client's state machine verifier to throw an error.

## Solution
Before emitting `RUN_FINISHED` in `splitRunIfToolFired()`, check if `messageStarted` is true and emit `TEXT_MESSAGE_END` if needed.

## Changes
- `src/http-handler.ts`: Added TEXT_MESSAGE_END guard in `splitRunIfToolFired()` (lines 383-390)
- `CHANGELOG.md`: Added 0.2.7 release entry
- `package.json`: Bumped version to 0.2.7

## Test plan
- [x] Code review - logic is sound
- [ ] Manual testing with AG-UI client in scenario that triggers the bug (text → tool → text)
- [ ] Verify SSE event sequence is valid (no protocol violations)
- [ ] Run existing test suite: `npm test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)