### PR TITLE
fix: reword comment that triggered its own security scanner warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.2.8 (2026-02-26)
+
+### Fixed
+- Remove literal `process.env` from a code comment in `http-handler.ts` that was itself triggering the security scanner — the comment documenting the v0.2.5/v0.2.6 fix contained the exact pattern the scanner flags
+
 ## 0.2.7 (2026-02-18)
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contextableai/clawg-ui",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "description": "AG-UI protocol channel plugin for OpenClaw — connect CopilotKit and AG-UI clients to your OpenClaw gateway",
   "type": "module",
   "license": "MIT",

--- a/src/http-handler.ts
+++ b/src/http-handler.ts
@@ -189,7 +189,7 @@ function buildBodyFromMessages(messages: Message[]): {
 export function createAguiHttpHandler(api: OpenClawPluginApi) {
   const runtime: PluginRuntime = api.runtime;
 
-  // Resolve once at init so the per-request handler never touches process.env.
+  // Resolve once at init so the per-request handler never touches env vars.
   const gatewaySecret = resolveGatewaySecret(api);
 
   return async function handleAguiRequest(


### PR DESCRIPTION
## Summary
- The comment added in v0.2.5 to explain the env-var separation contained the literal string `process.env`, which the scanner's `/process\.env/` regex matched — combined with `POST` elsewhere in the file matching `/\bpost\b/i`, this triggered the very "env-harvesting" warning the comment was documenting
- Reworded the comment to say "env vars" instead, confirmed clean scan with `scanSource()` directly
- Bumped to v0.2.8

Closes #8

## Test plan
- [x] Ran `scanSource()` against `http-handler.ts` — zero findings
- [x] Ran `scanDirectoryWithSummary()` against full `src/` — only test files flagged (not included in published package)

🤖 Generated with [Claude Code](https://claude.com/claude-code)