### PR TITLE
fix: compatibility with OpenClaw 2026.3.2 (v0.2.9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,14 @@
 # Changelog
 
-## Unreleased
+## 0.2.9 (2026-03-06)
 
 ### Fixed
+- Add `auth: "plugin"` to `registerHttpRoute` call — required by OpenClaw 2026.3.2; omitting it silently dropped the `/v1/clawg-ui` route, causing 404s
+- Pass `{ channel, accountId }` object to `readAllowFromStore` instead of a bare string — fixes 403 responses for approved devices after the pairing API changed in 2026.3.2
+- Add `pairing_code` and `bearer_token` at the root of the 403 pairing response alongside the existing nested `error.pairing` fields — restores compatibility with Kotlin `ClawgUIPairingResponse` clients expecting flat fields
+- Add diagnostic `console.log` for 400 responses to aid debugging of malformed requests
+
+### Changed
 - README event table was missing `TOOL_CALL_ARGS` and `TOOL_CALL_RESULT`; `tools` field incorrectly said "reserved for future use"
 - Integration tests used the gateway token directly instead of an HMAC-signed device token, causing 401s against v0.2.0+ servers
 - "Missing auth" integration test expected 401 instead of 403 (pairing initiation)
@@ -10,10 +16,10 @@
 ### Added
 - "Tool call events" documentation section explaining client vs server tool flows and diagnostic tips
 - Unit tests for `handleBeforeToolCall` and `handleToolResultPersist` hook handlers (`src/tool-hooks.test.ts`)
-
-### Changed
 - Extracted hook handlers from `index.ts` into exported named functions for testability (no behavioral change)
 - Integration tests now accept `CLAWG_UI_DEVICE_TOKEN` or auto-generate one from `OPENCLAW_GATEWAY_TOKEN` + `CLAWG_UI_DEVICE_ID`
+
+## Unreleased
 
 ## 0.2.8 (2026-02-26)
 

--- a/index.ts
+++ b/index.ts
@@ -145,6 +145,7 @@ const plugin = {
     api.registerTool(clawgUiToolFactory);
     api.registerHttpRoute({
       path: "/v1/clawg-ui",
+      auth: "plugin",
       handler: createAguiHttpHandler(api),
     });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contextableai/clawg-ui",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "description": "AG-UI protocol channel plugin for OpenClaw — connect CopilotKit and AG-UI clients to your OpenClaw gateway",
   "type": "module",
   "license": "MIT",

--- a/src/http-handler.ts
+++ b/src/http-handler.ts
@@ -245,6 +245,8 @@ export function createAguiHttpHandler(api: OpenClawPluginApi) {
 
       // Return pairing pending response with device token and pairing code
       sendJson(res, 403, {
+        pairing_code: pairingCode,
+        bearer_token: deviceToken,
         error: {
           type: "pairing_pending",
           message: "Device pending approval",
@@ -270,7 +272,7 @@ export function createAguiHttpHandler(api: OpenClawPluginApi) {
     // Pairing check: verify device is approved
     // ---------------------------------------------------------------------------
     const storeAllowFrom = await runtime.channel.pairing
-      .readAllowFromStore("clawg-ui")
+      .readAllowFromStore({ channel: "clawg-ui", accountId: "default" })
       .catch(() => []);
     const normalizedAllowFrom = storeAllowFrom.map((e) =>
       e.replace(/^clawg-ui:/i, "").toLowerCase(),
@@ -314,6 +316,9 @@ export function createAguiHttpHandler(api: OpenClawPluginApi) {
     const hasUserMessage = messages.some((m) => m.role === "user");
     const hasToolMessage = messages.some((m) => m.role === "tool");
     if (!hasUserMessage && !hasToolMessage) {
+      console.log(
+        `[clawg-ui] 400: no user/tool message, roles=[${messages.map((m) => m.role).join(",")}], messageCount=${messages.length}`,
+      );
       sendJson(res, 400, {
         error: {
           message: "At least one user or tool message is required in `messages`.",
@@ -326,6 +331,9 @@ export function createAguiHttpHandler(api: OpenClawPluginApi) {
     // Build body from messages
     const { body: messageBody } = buildBodyFromMessages(messages);
     if (!messageBody.trim()) {
+      console.log(
+        `[clawg-ui] 400: empty extracted body, roles=[${messages.map((m) => m.role).join(",")}], contents=[${messages.map((m) => JSON.stringify(m.content)).join(",")}]`,
+      );
       sendJson(res, 400, {
         error: {
           message: "Could not extract a prompt from `messages`.",


### PR DESCRIPTION
## Summary

- **Route 404 fix**: Added `auth: \"plugin\"` to `registerHttpRoute` — OpenClaw 2026.3.2 requires this field; omitting it silently drops the route with a diagnostic log
- **Pairing 403 fix**: Changed `readAllowFromStore(\"clawg-ui\")` to `readAllowFromStore({ channel: \"clawg-ui\", accountId: \"default\" })` — the pairing API changed in 2026.3.2, causing approved devices to keep getting 403s
- **Kotlin client fix**: Added flat `pairing_code` and `bearer_token` fields at the root of the 403 pairing response, alongside the existing `error.pairing` nested fields — restores compatibility with `ClawgUIPairingResponse` clients expecting flat fields
- **Diagnostics**: Added `console.log` for 400 responses to log message roles/content for debugging

## Test plan

- [x] Unit tests: `pnpm test` — 37/37 pass
- [x] Integration tests: 12/13 pass (1 timeout on client-tool test due to local Ollama model not reliably calling tools on demand — not a handler bug)

🤖 Generated with [Claude Code](https://claude.com/claude-code)