### PR TITLE
Implement X-OpenClaw-Agent-Id header routing via accountId binding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.4.3 (2026-03-14)
+
+### Added
+- Implement `X-OpenClaw-Agent-Id` header routing — pass the header value as `accountId` to `resolveAgentRoute`, enabling agent selection via bindings (e.g. `{ "agentId": "auditor", "match": { "channel": "clawg-ui", "accountId": "auditor" } }`)
+
 ## 0.4.2 (2026-03-13)
 
 ### Removed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contextableai/clawg-ui",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "AG-UI protocol channel plugin for OpenClaw — connect CopilotKit and AG-UI clients to your OpenClaw gateway",
   "type": "module",
   "license": "MIT",

--- a/src/http-handler.test.ts
+++ b/src/http-handler.test.ts
@@ -587,6 +587,53 @@ describe("AG-UI HTTP handler", () => {
     expect(types).toContain(EventType.RUN_FINISHED);
   });
 
+  it("passes X-OpenClaw-Agent-Id header as accountId to resolveAgentRoute", async () => {
+    const token = createDeviceToken(GATEWAY_SECRET, APPROVED_DEVICE_ID);
+    const req = createReq({
+      headers: {
+        authorization: `Bearer ${token}`,
+        "x-openclaw-agent-id": "auditor",
+      },
+      body: {
+        threadId: "t-agent",
+        runId: "r-agent",
+        messages: [{ role: "user", content: "Hello auditor" }],
+      },
+    });
+    const res = createRes();
+    await handler(req, res);
+
+    const rt = (fakeApi as any).runtime;
+    expect(rt.channel.routing.resolveAgentRoute).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "clawg-ui",
+        accountId: "auditor",
+      }),
+    );
+  });
+
+  it("does not pass accountId when X-OpenClaw-Agent-Id header is absent", async () => {
+    const token = createDeviceToken(GATEWAY_SECRET, APPROVED_DEVICE_ID);
+    const req = createReq({
+      headers: { authorization: `Bearer ${token}` },
+      body: {
+        threadId: "t-no-agent",
+        runId: "r-no-agent",
+        messages: [{ role: "user", content: "Hello" }],
+      },
+    });
+    const res = createRes();
+    await handler(req, res);
+
+    const rt = (fakeApi as any).runtime;
+    expect(rt.channel.routing.resolveAgentRoute).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "clawg-ui",
+        accountId: undefined,
+      }),
+    );
+  });
+
   it("handles client disconnect by aborting", async () => {
     const rt = (fakeApi as any).runtime;
     let capturedAbortSignal: AbortSignal | undefined;

--- a/src/http-handler.ts
+++ b/src/http-handler.ts
@@ -356,10 +356,15 @@ export function createAguiHttpHandler(api: OpenClawPluginApi) {
 
     // Resolve agent route
     const cfg = runtime.config.loadConfig();
+    const agentIdHeader =
+      typeof req.headers["x-openclaw-agent-id"] === "string"
+        ? req.headers["x-openclaw-agent-id"]
+        : undefined;
     const route = runtime.channel.routing.resolveAgentRoute({
       cfg,
       channel: "clawg-ui",
       peer: { kind: "dm", id: `clawg-ui-${threadId}` },
+      accountId: agentIdHeader,
     });
 
     // Set up SSE via EventEncoder


### PR DESCRIPTION
Pass the X-OpenClaw-Agent-Id header value as accountId to resolveAgentRoute, enabling agent selection through the existing binding system. Bumps version to 0.4.3.