### PR TITLE
feat: Add X-OpenClaw-Session-Key header support for per-user sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,6 +319,46 @@ curl -N -X POST http://localhost:18789/v1/clawg-ui \
   -d '{"messages":[{"role":"user","content":"Hello"}]}'
 ```
 
+## Session isolation
+
+By default, sessions are keyed by `route.sessionKey` plus a `:thread:<threadId>` suffix so each thread gets its own session within the device. For multi-user applications where each user needs isolated conversation history within a shared AG-UI client, pass the `X-OpenClaw-Session-Key` header to add a `:user:<value>` scope on top:
+
+```bash
+curl -N -X POST http://localhost:18789/v1/clawg-ui \
+  -H "Authorization: Bearer $CLAWG_UI_DEVICE_TOKEN" \
+  -H "X-OpenClaw-Session-Key: user@example.com" \
+  -d '{"messages":[{"role":"user","content":"Hello"}]}'
+```
+
+This is useful when:
+- Multiple authenticated users share the same AG-UI client (e.g., a web app with auth)
+- You want to key sessions by user identity *in addition to* thread ID
+- CopilotKit or other AG-UI clients manage `threadId` internally
+
+### How the final session key is composed
+
+The header **scopes** the route-derived key; it does not replace it:
+
+```
+<route.sessionKey>[:user:<header>][:thread:<threadId>]
+```
+
+With no header, the session key is `<route.sessionKey>:thread:<threadId>` (existing behaviour). With the header set to `alice@example.com` and `threadId: "t-1"`, it becomes `<route.sessionKey>:user:alice@example.com:thread:t-1`. The header can only subdivide an existing route scope — it cannot escape it.
+
+### Trust model — treat this header like `X-Forwarded-For`
+
+`X-OpenClaw-Session-Key` is a **trusted-proxy-only** concern, in the same family as `X-Forwarded-For` and `X-Request-ID`. It is expected to be set by a reverse proxy or authentication middleware that has already authenticated the user — not by end clients.
+
+Deployments that are reachable by untrusted clients **must strip or overwrite this header at the ingress edge** before forwarding to the gateway. If an end client can set this header freely, they can impersonate any other user's session scope for that same device.
+
+### Validation
+
+The header value must match these rules; invalid values return `HTTP 400 invalid_request_error` and the agent is not dispatched:
+
+- 1–256 characters after trimming
+- Characters restricted to `[A-Za-z0-9._@:-]` (covers emails, UUIDs, and colon-separated identifiers)
+- No path-traversal sequences: rejects `..` as a substring, slashes (`/`, `\`), and null bytes
+
 ## Error responses
 
 Non-streaming errors return JSON:

--- a/src/http-handler.test.ts
+++ b/src/http-handler.test.ts
@@ -637,6 +637,224 @@ describe("AG-UI HTTP handler", () => {
     expect(call.ctx.SessionKey).toMatch(/^agui:test-session:thread:clawg-ui-/);
   });
 
+  // -------------------------------------------------------------------------
+  // X-OpenClaw-Session-Key — per-user session scoping
+  // -------------------------------------------------------------------------
+
+  it("appends user suffix to session key when X-OpenClaw-Session-Key is provided", async () => {
+    const token = createDeviceToken(GATEWAY_SECRET, APPROVED_DEVICE_ID);
+    const req = createReq({
+      headers: {
+        authorization: `Bearer ${token}`,
+        "x-openclaw-session-key": "alice@example.com",
+      },
+      body: {
+        threadId: "t-user",
+        runId: "r-user",
+        messages: [{ role: "user", content: "Hello" }],
+      },
+    });
+    const res = createRes();
+    await handler(req, res);
+
+    const rt = (fakeApi as any).runtime;
+    const call = rt.channel.reply.dispatchReplyFromConfig.mock.calls[0][0];
+    expect(call.ctx.SessionKey).toBe(
+      "agui:test-session:user:alice@example.com:thread:t-user",
+    );
+  });
+
+  it("composes user and thread suffixes together in order", async () => {
+    const token = createDeviceToken(GATEWAY_SECRET, APPROVED_DEVICE_ID);
+    const req = createReq({
+      headers: {
+        authorization: `Bearer ${token}`,
+        "x-openclaw-session-key": "alice",
+      },
+      body: {
+        threadId: "t-1",
+        runId: "r-1",
+        messages: [{ role: "user", content: "Hello" }],
+      },
+    });
+    const res = createRes();
+    await handler(req, res);
+
+    const rt = (fakeApi as any).runtime;
+    const call = rt.channel.reply.dispatchReplyFromConfig.mock.calls[0][0];
+    expect(call.ctx.SessionKey).toBe("agui:test-session:user:alice:thread:t-1");
+  });
+
+  it("namespaces header value under route.sessionKey and never replaces it", async () => {
+    const token = createDeviceToken(GATEWAY_SECRET, APPROVED_DEVICE_ID);
+    const req = createReq({
+      headers: {
+        authorization: `Bearer ${token}`,
+        "x-openclaw-session-key": "totally-different",
+      },
+      body: {
+        threadId: "t-hostile",
+        runId: "r-hostile",
+        messages: [{ role: "user", content: "Hello" }],
+      },
+    });
+    const res = createRes();
+    await handler(req, res);
+
+    const rt = (fakeApi as any).runtime;
+    const call = rt.channel.reply.dispatchReplyFromConfig.mock.calls[0][0];
+    expect(call.ctx.SessionKey.startsWith("agui:test-session:")).toBe(true);
+    expect(call.ctx.SessionKey).toContain(":user:totally-different");
+  });
+
+  it("falls back to route.sessionKey scoping when X-OpenClaw-Session-Key is absent", async () => {
+    const token = createDeviceToken(GATEWAY_SECRET, APPROVED_DEVICE_ID);
+    const req = createReq({
+      headers: { authorization: `Bearer ${token}` },
+      body: {
+        threadId: "t-nouser",
+        runId: "r-nouser",
+        messages: [{ role: "user", content: "Hello" }],
+      },
+    });
+    const res = createRes();
+    await handler(req, res);
+
+    const rt = (fakeApi as any).runtime;
+    const call = rt.channel.reply.dispatchReplyFromConfig.mock.calls[0][0];
+    expect(call.ctx.SessionKey).toBe("agui:test-session:thread:t-nouser");
+    expect(call.ctx.SessionKey).not.toContain(":user:");
+  });
+
+  it.each([
+    ["path traversal", "../evil"],
+    ["forward slash", "a/b"],
+    ["backslash", "a\\b"],
+    ["null byte", "a\0b"],
+  ])(
+    "rejects X-OpenClaw-Session-Key with %s (400 invalid_request_error)",
+    async (_label, value) => {
+      const token = createDeviceToken(GATEWAY_SECRET, APPROVED_DEVICE_ID);
+      const req = createReq({
+        headers: {
+          authorization: `Bearer ${token}`,
+          "x-openclaw-session-key": value,
+        },
+        body: {
+          threadId: "t",
+          runId: "r",
+          messages: [{ role: "user", content: "Hello" }],
+        },
+      });
+      const res = createRes();
+      await handler(req, res);
+
+      expect(res.statusCode).toBe(400);
+      const body = JSON.parse(res._chunks.join(""));
+      expect(body.error.type).toBe("invalid_request_error");
+    },
+  );
+
+  it("rejects X-OpenClaw-Session-Key exceeding 256 characters", async () => {
+    const token = createDeviceToken(GATEWAY_SECRET, APPROVED_DEVICE_ID);
+    const req = createReq({
+      headers: {
+        authorization: `Bearer ${token}`,
+        "x-openclaw-session-key": "a".repeat(257),
+      },
+      body: {
+        threadId: "t",
+        runId: "r",
+        messages: [{ role: "user", content: "Hello" }],
+      },
+    });
+    const res = createRes();
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(400);
+    const body = JSON.parse(res._chunks.join(""));
+    expect(body.error.type).toBe("invalid_request_error");
+  });
+
+  it.each([
+    ["whitespace", "alice space"],
+    ["exclamation", "alice!"],
+    ["hash", "alice#b"],
+  ])(
+    "rejects X-OpenClaw-Session-Key with disallowed character (%s)",
+    async (_label, value) => {
+      const token = createDeviceToken(GATEWAY_SECRET, APPROVED_DEVICE_ID);
+      const req = createReq({
+        headers: {
+          authorization: `Bearer ${token}`,
+          "x-openclaw-session-key": value,
+        },
+        body: {
+          threadId: "t",
+          runId: "r",
+          messages: [{ role: "user", content: "Hello" }],
+        },
+      });
+      const res = createRes();
+      await handler(req, res);
+
+      expect(res.statusCode).toBe(400);
+    },
+  );
+
+  it.each([
+    ["email", "alice@example.com"],
+    ["uuid", "12345678-1234-1234-1234-123456789abc"],
+    ["colon-separated", "tenant-1:alice"],
+    ["dot-and-underscore", "user_1.alice"],
+  ])(
+    "accepts well-formed identifier (%s) and composes it under route.sessionKey",
+    async (_label, value) => {
+      const token = createDeviceToken(GATEWAY_SECRET, APPROVED_DEVICE_ID);
+      const req = createReq({
+        headers: {
+          authorization: `Bearer ${token}`,
+          "x-openclaw-session-key": value,
+        },
+        body: {
+          threadId: "t-ok",
+          runId: "r-ok",
+          messages: [{ role: "user", content: "Hello" }],
+        },
+      });
+      const res = createRes();
+      await handler(req, res);
+
+      expect(res.statusCode).toBe(200);
+      const rt = (fakeApi as any).runtime;
+      const call = rt.channel.reply.dispatchReplyFromConfig.mock.calls[0][0];
+      expect(call.ctx.SessionKey).toBe(
+        `agui:test-session:user:${value}:thread:t-ok`,
+      );
+    },
+  );
+
+  it("does not call resolveAgentRoute or dispatchReplyFromConfig when X-OpenClaw-Session-Key is invalid", async () => {
+    const token = createDeviceToken(GATEWAY_SECRET, APPROVED_DEVICE_ID);
+    const req = createReq({
+      headers: {
+        authorization: `Bearer ${token}`,
+        "x-openclaw-session-key": "../escape",
+      },
+      body: {
+        threadId: "t",
+        runId: "r",
+        messages: [{ role: "user", content: "Hello" }],
+      },
+    });
+    const res = createRes();
+    await handler(req, res);
+
+    const rt = (fakeApi as any).runtime;
+    expect(rt.channel.routing.resolveAgentRoute).not.toHaveBeenCalled();
+    expect(rt.channel.reply.dispatchReplyFromConfig).not.toHaveBeenCalled();
+  });
+
   it("handles client disconnect by aborting", async () => {
     const rt = (fakeApi as any).runtime;
     let capturedAbortSignal: AbortSignal | undefined;

--- a/src/http-handler.ts
+++ b/src/http-handler.ts
@@ -70,6 +70,27 @@ function getBearerToken(req: IncomingMessage): string | undefined {
 }
 
 // ---------------------------------------------------------------------------
+// Session-key header validation
+// ---------------------------------------------------------------------------
+
+/**
+ * Validate an `X-OpenClaw-Session-Key` header value.
+ *
+ * Returns the trimmed value if valid, or `null` if it must be rejected.
+ * The header is intended to be set by a trusted reverse proxy that has
+ * already authenticated the user — we still validate defensively so a
+ * misconfigured proxy or a bypass cannot introduce path-traversal or
+ * oversized keys into the session store.
+ */
+function validateSessionKeyHeader(raw: string): string | null {
+  const v = raw.trim();
+  if (!v || v.length > 256) return null;
+  if (v.includes("..") || /[/\\\0]/.test(v)) return null;
+  if (!/^[A-Za-z0-9._@:-]+$/.test(v)) return null;
+  return v;
+}
+
+// ---------------------------------------------------------------------------
 // HMAC-signed device token utilities
 // ---------------------------------------------------------------------------
 
@@ -379,6 +400,29 @@ export function createAguiHttpHandler(api: OpenClawPluginApi) {
       typeof req.headers["x-openclaw-agent-id"] === "string"
         ? req.headers["x-openclaw-agent-id"]
         : undefined;
+
+    // Support custom session key via header for per-user isolation.
+    // Treated as a trusted-proxy-only concern (see README "Session isolation"):
+    // the value only *scopes* route.sessionKey — it never replaces it.
+    const sessionKeyHeader =
+      typeof req.headers["x-openclaw-session-key"] === "string"
+        ? req.headers["x-openclaw-session-key"]
+        : undefined;
+    let userKey: string | undefined;
+    if (sessionKeyHeader !== undefined) {
+      const validated = validateSessionKeyHeader(sessionKeyHeader);
+      if (!validated) {
+        sendJson(res, 400, {
+          error: {
+            message: "Invalid X-OpenClaw-Session-Key header.",
+            type: "invalid_request_error",
+          },
+        });
+        return;
+      }
+      userKey = validated;
+    }
+
     const route = runtime.channel.routing.resolveAgentRoute({
       cfg,
       channel: "clawg-ui",
@@ -428,11 +472,13 @@ export function createAguiHttpHandler(api: OpenClawPluginApi) {
       runId,
     });
 
-    // Build inbound context using the plugin runtime (same pattern as msteams)
-    // Append thread suffix so each thread gets its own session within the device
-    const sessionKey = threadId
-      ? `${route.sessionKey}:thread:${threadId.toLowerCase()}`
-      : route.sessionKey;
+    // Build inbound context using the plugin runtime (same pattern as msteams).
+    // Compose session scopes under route.sessionKey — the :user: suffix (from
+    // the validated header) and the :thread: suffix both subdivide the route
+    // scope and never replace it.
+    let sessionKey = route.sessionKey;
+    if (userKey) sessionKey += `:user:${userKey}`;
+    if (threadId) sessionKey += `:thread:${threadId.toLowerCase()}`;
 
     // Stash client-provided tools so the plugin tool factory can pick them up
     if (Array.isArray(input.tools) && input.tools.length > 0) {


### PR DESCRIPTION
Adds support for the `X-OpenClaw-Session-Key` header to enable per-user session isolation in multi-user applications.

When the header is present, it overrides the route-derived session key, allowing applications to key sessions by user identity rather than threadId.

Use case: Web apps where multiple authenticated users share an AG-UI client (e.g., CopilotKit) and need isolated conversation histories.