### PR TITLE
Use device ID as peer + fix HTTP route for OpenClaw 3.23+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.5.2 (2026-04-02)
+
+### Fixed
+- Use `registerPluginHttpRoute()` from the plugin SDK instead of `api.registerHttpRoute()` to work around a known OpenClaw startup timing issue where plugin HTTP routes registered via `api.registerHttpRoute()` are not included in the pinned HTTP route registry. This affected OpenClaw 2026.3.23+ where the gateway pins the HTTP route registry before external plugin `register()` callbacks complete.
+
 ## 0.5.1 (2026-04-01)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,14 @@
 # Changelog
 
-## 0.5.3 (2026-04-02)
+## 0.5.4 (2026-04-02)
 
 ### Fixed
-- Register HTTP route via `gateway_start` lifecycle hook instead of directly in `register()`. Works around a known OpenClaw startup timing issue (2026.3.23+) where the gateway pins the HTTP route registry before external plugin `register()` callbacks complete, causing routes registered via `api.registerHttpRoute()` to be silently lost.
+- Use `registerPluginHttpRoute()` from `openclaw/plugin-sdk/plugin-runtime` (dynamic import) to write directly to the pinned HTTP route registry. This is the correct fix for the startup timing issue — `api.registerHttpRoute()` writes to the loader's private registry which the HTTP handler never reads, regardless of when it's called.
+
+## 0.5.3 (2026-04-02) [yanked]
+
+### Fixed
+- Attempted `gateway_start` hook approach — `api.registerHttpRoute()` still writes to the wrong registry even when called post-startup. Use 0.5.4 instead.
 
 ## 0.5.2 (2026-04-02) [yanked]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,14 @@
 # Changelog
 
-## 0.5.2 (2026-04-02)
+## 0.5.3 (2026-04-02)
 
 ### Fixed
-- Use `registerPluginHttpRoute()` from the plugin SDK instead of `api.registerHttpRoute()` to work around a known OpenClaw startup timing issue where plugin HTTP routes registered via `api.registerHttpRoute()` are not included in the pinned HTTP route registry. This affected OpenClaw 2026.3.23+ where the gateway pins the HTTP route registry before external plugin `register()` callbacks complete.
+- Register HTTP route via `gateway_start` lifecycle hook instead of directly in `register()`. Works around a known OpenClaw startup timing issue (2026.3.23+) where the gateway pins the HTTP route registry before external plugin `register()` callbacks complete, causing routes registered via `api.registerHttpRoute()` to be silently lost.
+
+## 0.5.2 (2026-04-02) [yanked]
+
+### Fixed
+- Attempted to use `registerPluginHttpRoute()` from the plugin SDK — not exported in the public SDK. Use 0.5.3 instead.
 
 ## 0.5.1 (2026-04-01)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## 0.5.0 (2026-04-01)
+
+### Changed
+- **Breaking:** Peer ID now uses the stable device UUID instead of the per-thread ID. This enables identity linking (`session.identityLinks`) so clawg-ui devices can be linked to users across channels, matching how Telegram and Slack connections work.
+- Session keys now include a `:thread:<threadId>` suffix for per-thread session separation (same pattern as Slack thread sessions).
+
+### Migration
+- **Identity linking:** You can now add clawg-ui device IDs to `session.identityLinks` in `openclaw.json`:
+  ```json
+  {
+    "session": {
+      "dmScope": "per-peer",
+      "identityLinks": {
+        "alice": ["clawg-ui:<deviceId>", "telegram:123456", "slack:U0123ABC"]
+      }
+    }
+  }
+  ```
+  The device UUID is shown during pairing approval (`openclaw pairing list clawg-ui`).
+- **Session history:** Existing session histories are keyed on the old format (`clawg-ui-<threadId>` peer). After upgrading, devices will start new sessions. No data is lost — old sessions remain in the store but won't be matched by the new key format.
+
 ## 0.4.5 (2026-03-15)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.5.1 (2026-04-01)
+
+### Fixed
+- Add `match: "exact"` to `registerHttpRoute` call — required by OpenClaw 2026.3.23+ which changed the plugin HTTP route API to require an explicit match mode. Without it, the route registers silently but never matches incoming requests, resulting in a 404. Backwards compatible with older OpenClaw versions (unknown properties are ignored).
+
 ## 0.5.0 (2026-04-01)
 
 ### Changed

--- a/index.ts
+++ b/index.ts
@@ -1,6 +1,6 @@
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 import type { Command } from "commander";
-import { emptyPluginConfigSchema } from "openclaw/plugin-sdk";
+import { emptyPluginConfigSchema, registerPluginHttpRoute } from "openclaw/plugin-sdk";
 import { randomUUID } from "node:crypto";
 import { EventType } from "@ag-ui/core";
 import { aguiChannelPlugin } from "./src/channel.js";
@@ -149,11 +149,12 @@ const plugin: {
   register(api: OpenClawPluginApi) {
     api.registerChannel({ plugin: aguiChannelPlugin });
     api.registerTool(clawgUiToolFactory);
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- auth/match not yet in SDK typings but required at runtime
-    (api.registerHttpRoute as (params: any) => void)({
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- auth/match added in newer SDK
+    (registerPluginHttpRoute as (params: any) => () => void)({
       path: "/v1/clawg-ui",
-      match: "exact",
       auth: "plugin",
+      match: "exact",
+      pluginId: "clawg-ui",
       handler: createAguiHttpHandler(api),
     });
 

--- a/index.ts
+++ b/index.ts
@@ -149,16 +149,16 @@ const plugin: {
   register(api: OpenClawPluginApi) {
     api.registerChannel({ plugin: aguiChannelPlugin });
     api.registerTool(clawgUiToolFactory);
-    // Register HTTP route via gateway_start hook to ensure the pinned HTTP
-    // route registry is available (api.registerHttpRoute in register() runs
-    // before the registry is pinned, so routes are silently lost).
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- gateway_start not yet in SDK typings
-    (api.on as any)("gateway_start", () => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- auth/match not yet in SDK typings
-      (api.registerHttpRoute as (params: any) => void)({
+    // Use registerPluginHttpRoute from plugin-runtime which writes directly to
+    // the pinned HTTP route registry. api.registerHttpRoute writes to the
+    // loader's private registry which is not the one the HTTP handler reads.
+    // @ts-expect-error -- openclaw/plugin-sdk/plugin-runtime is not in local SDK typings but exists at runtime
+    import("openclaw/plugin-sdk/plugin-runtime").then((mod: any) => {
+      mod.registerPluginHttpRoute({
         path: "/v1/clawg-ui",
-        match: "exact",
         auth: "plugin",
+        match: "exact",
+        pluginId: "clawg-ui",
         handler: createAguiHttpHandler(api),
       });
     });

--- a/index.ts
+++ b/index.ts
@@ -1,6 +1,6 @@
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 import type { Command } from "commander";
-import { emptyPluginConfigSchema, registerPluginHttpRoute } from "openclaw/plugin-sdk";
+import { emptyPluginConfigSchema } from "openclaw/plugin-sdk";
 import { randomUUID } from "node:crypto";
 import { EventType } from "@ag-ui/core";
 import { aguiChannelPlugin } from "./src/channel.js";
@@ -149,13 +149,18 @@ const plugin: {
   register(api: OpenClawPluginApi) {
     api.registerChannel({ plugin: aguiChannelPlugin });
     api.registerTool(clawgUiToolFactory);
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- auth/match added in newer SDK
-    (registerPluginHttpRoute as (params: any) => () => void)({
-      path: "/v1/clawg-ui",
-      auth: "plugin",
-      match: "exact",
-      pluginId: "clawg-ui",
-      handler: createAguiHttpHandler(api),
+    // Register HTTP route via gateway_start hook to ensure the pinned HTTP
+    // route registry is available (api.registerHttpRoute in register() runs
+    // before the registry is pinned, so routes are silently lost).
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- gateway_start not yet in SDK typings
+    (api.on as any)("gateway_start", () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- auth/match not yet in SDK typings
+      (api.registerHttpRoute as (params: any) => void)({
+        path: "/v1/clawg-ui",
+        match: "exact",
+        auth: "plugin",
+        handler: createAguiHttpHandler(api),
+      });
     });
 
     api.on("before_tool_call", handleBeforeToolCall);

--- a/index.ts
+++ b/index.ts
@@ -149,9 +149,10 @@ const plugin: {
   register(api: OpenClawPluginApi) {
     api.registerChannel({ plugin: aguiChannelPlugin });
     api.registerTool(clawgUiToolFactory);
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- auth not yet in SDK typings but required at runtime
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- auth/match not yet in SDK typings but required at runtime
     (api.registerHttpRoute as (params: any) => void)({
       path: "/v1/clawg-ui",
+      match: "exact",
       auth: "plugin",
       handler: createAguiHttpHandler(api),
     });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contextableai/clawg-ui",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "AG-UI protocol channel plugin for OpenClaw — connect CopilotKit and AG-UI clients to your OpenClaw gateway",
   "type": "module",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contextableai/clawg-ui",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "AG-UI protocol channel plugin for OpenClaw — connect CopilotKit and AG-UI clients to your OpenClaw gateway",
   "type": "module",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contextableai/clawg-ui",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "AG-UI protocol channel plugin for OpenClaw — connect CopilotKit and AG-UI clients to your OpenClaw gateway",
   "type": "module",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contextableai/clawg-ui",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "AG-UI protocol channel plugin for OpenClaw — connect CopilotKit and AG-UI clients to your OpenClaw gateway",
   "type": "module",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contextableai/clawg-ui",
-  "version": "0.4.5",
+  "version": "0.5.0",
   "description": "AG-UI protocol channel plugin for OpenClaw — connect CopilotKit and AG-UI clients to your OpenClaw gateway",
   "type": "module",
   "license": "MIT",

--- a/src/http-handler.test.ts
+++ b/src/http-handler.test.ts
@@ -341,7 +341,7 @@ describe("AG-UI HTTP handler", () => {
     const rt = (fakeApi as any).runtime;
     expect(rt.channel.reply.dispatchReplyFromConfig).toHaveBeenCalledTimes(1);
     const call = rt.channel.reply.dispatchReplyFromConfig.mock.calls[0][0];
-    expect(call.ctx.SessionKey).toBe("agui:test-session");
+    expect(call.ctx.SessionKey).toBe("agui:test-session:thread:t1");
     expect(call.replyOptions.runId).toBe("r1");
   });
 
@@ -632,6 +632,64 @@ describe("AG-UI HTTP handler", () => {
         accountId: undefined,
       }),
     );
+  });
+
+  it("uses deviceId as peer ID for identity linking", async () => {
+    const token = createDeviceToken(GATEWAY_SECRET, APPROVED_DEVICE_ID);
+    const req = createReq({
+      headers: { authorization: `Bearer ${token}` },
+      body: {
+        threadId: "t-peer",
+        runId: "r-peer",
+        messages: [{ role: "user", content: "Hello" }],
+      },
+    });
+    const res = createRes();
+    await handler(req, res);
+
+    const rt = (fakeApi as any).runtime;
+    expect(rt.channel.routing.resolveAgentRoute).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel: "clawg-ui",
+        peer: { kind: "dm", id: APPROVED_DEVICE_ID },
+      }),
+    );
+  });
+
+  it("appends thread suffix to session key for thread separation", async () => {
+    const token = createDeviceToken(GATEWAY_SECRET, APPROVED_DEVICE_ID);
+    const req = createReq({
+      headers: { authorization: `Bearer ${token}` },
+      body: {
+        threadId: "My-Thread-42",
+        runId: "r-thread",
+        messages: [{ role: "user", content: "Hello" }],
+      },
+    });
+    const res = createRes();
+    await handler(req, res);
+
+    const rt = (fakeApi as any).runtime;
+    const call = rt.channel.reply.dispatchReplyFromConfig.mock.calls[0][0];
+    expect(call.ctx.SessionKey).toBe("agui:test-session:thread:my-thread-42");
+  });
+
+  it("uses base session key when threadId is absent", async () => {
+    const token = createDeviceToken(GATEWAY_SECRET, APPROVED_DEVICE_ID);
+    const req = createReq({
+      headers: { authorization: `Bearer ${token}` },
+      body: {
+        runId: "r-no-thread",
+        messages: [{ role: "user", content: "Hello" }],
+      },
+    });
+    const res = createRes();
+    await handler(req, res);
+
+    const rt = (fakeApi as any).runtime;
+    const call = rt.channel.reply.dispatchReplyFromConfig.mock.calls[0][0];
+    // threadId defaults to "clawg-ui-<uuid>" so it will have a thread suffix
+    expect(call.ctx.SessionKey).toMatch(/^agui:test-session:thread:clawg-ui-/);
   });
 
   it("handles client disconnect by aborting", async () => {

--- a/src/http-handler.ts
+++ b/src/http-handler.ts
@@ -383,7 +383,7 @@ export function createAguiHttpHandler(api: OpenClawPluginApi) {
     const route = runtime.channel.routing.resolveAgentRoute({
       cfg,
       channel: "clawg-ui",
-      peer: { kind: "dm", id: `clawg-ui-${threadId}` },
+      peer: { kind: "dm", id: deviceId },
       accountId: agentIdHeader,
     });
 
@@ -464,7 +464,10 @@ export function createAguiHttpHandler(api: OpenClawPluginApi) {
     });
 
     // Build inbound context using the plugin runtime (same pattern as msteams)
-    const sessionKey = route.sessionKey;
+    // Append thread suffix so each thread gets its own session within the device
+    const sessionKey = threadId
+      ? `${route.sessionKey}:thread:${threadId.toLowerCase()}`
+      : route.sessionKey;
 
     // Stash client-provided tools so the plugin tool factory can pick them up
     if (Array.isArray(input.tools) && input.tools.length > 0) {


### PR DESCRIPTION
## Summary
- **Breaking:** Use stable device UUID as peer ID instead of per-thread ID, enabling identity linking (`session.identityLinks`) across channels — matching how Telegram and Slack connections work
- Fix HTTP route registration by using `registerPluginHttpRoute` from `openclaw/plugin-sdk/plugin-runtime` via dynamic import, which writes directly to the pinned HTTP route registry. `api.registerHttpRoute()` writes to the loader's private registry which the HTTP handler never reads — a known timing issue in OpenClaw 2026.3.23+.
- Add `match: "exact"` for OpenClaw 3.23+ route matching compatibility

## Migration
- **Identity linking:** Device UUIDs can now be added to `session.identityLinks` in `openclaw.json`:
  ```json
  {
    "session": {
      "dmScope": "per-peer",
      "identityLinks": {
        "alice": ["clawg-ui:<deviceId>", "telegram:123456", "slack:U0123ABC"]
      }
    }
  }
  ```
  The device UUID is shown during pairing approval (`openclaw pairing list clawg-ui`).
- **Session history:** Existing sessions keyed on old format (`clawg-ui-<threadId>`) won't be matched; devices will start new sessions after upgrade. No data is lost.

## Test plan
- [x] All 48 unit tests pass
- [x] Verified HTTP route responds (no 404) on OpenClaw 2026.4.1
- [ ] Verify pairing flow works with new peer ID
- [ ] Verify identity linking works with device UUID

🤖 Generated with [Claude Code](https://claude.com/claude-code)