### PR TITLE
Add A2UI v0.9 support and CopilotKit compatibility fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## 0.6.3 (2026-04-07)
+
+### Added
+- **A2UI v0.9 support** — detect `{ "a2ui_operations": [...] }` in server-side tool results and emit `ACTIVITY_SNAPSHOT` events over the AG-UI SSE stream. CopilotKit clients with A2UI rendering enabled will display rich interactive surfaces (cards, lists, forms) instead of raw JSON.
+- **`cron_report` example tool** (`examples/cron-report-tool.ts`) — server-side tool that wraps cron job run data in a fixed A2UI v0.9 card layout (horizontal scrollable list of cards with startedAt, duration, model, tokensUsed, summary). Registered as `optional: true` — agents must opt in via `tools.alsoAllow: ["cron_report"]`.
+- **Example setup guide** (`examples/SETUP.md`) — step-by-step instructions for configuring a dedicated cron report demo agent with `X-OpenClaw-Agent-Id` header routing.
+- New `src/a2ui.ts` module with detection utilities: `tryParseA2UIOperations`, `extractToolResultText`, `groupBySurface`, `getOperationSurfaceId`.
+
+### Fixed
+- **CopilotKit compatibility: single-run event stream** — removed `splitRunIfToolFired()` which split tool calls and text into separate AG-UI runs. CopilotKit closes the SSE connection on `RUN_FINISHED`, so the second run's text was never received. The entire agent turn (tool calls + follow-up text) now stays in a single `RUN_STARTED`/`RUN_FINISHED` pair.
+- **`TOOL_CALL_RESULT` content** — was always emitted as `content: ""`. Now populated with the actual tool result text extracted from the OpenClaw `tool_result_persist` hook event.
+- **`messageId` collision** — `TOOL_CALL_RESULT` and `TEXT_MESSAGE_START` shared the same `messageId`, causing CopilotKit to overwrite the tool result with the text message. Tool results now use a dedicated `messageId` (`msg-tool-<toolCallId>`), while text messages keep `msg-<uuid>`.
+- **HTTP route registration** — restored the proven v0.5.4 pattern (`registerPluginHttpRoute` via `openclaw/plugin-sdk/plugin-runtime`) after the `gateway_start` hook approach (0.6.1) caused 404s on deployed servers.
+
+### Changed
+- Examples are excluded from the npm package (`!dist/examples` in `files`). The `cron_report` tool loads via dynamic import with a silent `.catch()` fallback — safe for npm installs where `examples/` doesn't exist.
+
 ## 0.5.4 (2026-04-02)
 
 ### Fixed

--- a/examples/SETUP.md
+++ b/examples/SETUP.md
@@ -1,0 +1,165 @@
+# Cron Report Demo Setup
+
+This guide walks through setting up a dedicated OpenClaw agent for the Cron Report A2UI demo, accessible via the `X-OpenClaw-Agent-Id` header from an AG-UI client (e.g. the CopilotKit Dojo app).
+
+## Prerequisites
+
+- OpenClaw gateway running with clawg-ui plugin installed
+- An approved clawg-ui device (see main README for pairing)
+- The `cron` tool enabled globally or for the agent (provides job history)
+
+## 1. Add the agent to `openclaw.json`
+
+Add a new agent entry under `agents.list`:
+
+```json5
+{
+  "agents": {
+    "list": [
+      // ... your existing agents ...
+      {
+        "id": "cron-demo",
+        "name": "Cron Demo",
+        "tools": {
+          "profile": "minimal",
+          "alsoAllow": ["cron_report", "cron"]
+        }
+      }
+    ]
+  }
+}
+```
+
+- **`cron_report`** (optional, from clawg-ui plugin) -- wraps run data in A2UI v0.9 cards
+- **`cron`** (built-in) -- gives the agent access to `{"action": "runs", "jobId": "..."}` for real cron job history
+
+The `cron_report` tool is registered with `optional: true`, so it only activates for agents that explicitly allow it.
+
+## 2. Add the agent system prompt
+
+Create or edit the workspace bootstrap file for the agent. If using a shared workspace, add to `AGENTS.md`:
+
+```
+~/.openclaw/workspace/AGENTS.md
+```
+
+Or if the agent has its own workspace directory:
+
+```
+~/.openclaw/workspace-cron-demo/AGENTS.md
+```
+
+Contents:
+
+```markdown
+You are a CI/CD monitoring assistant for scheduled automation runs.
+
+When the user asks about cron jobs, automation runs, or scheduled tasks:
+1. Use the `cron` tool with `{"action": "runs", "jobId": "..."}` to retrieve run history
+2. Reshape the results into the cron_report schema
+3. Call `cron_report` with the results
+
+For each run, gather:
+- id: unique run identifier
+- startedAt: when the run started (readable format, e.g. "Apr 5, 10:30 AM")
+- duration: how long it took (e.g. "2m 14s")
+- model: which LLM model was used (e.g. "claude-sonnet-4-6")
+- tokensUsed: total tokens consumed (formatted with commas, e.g. "12,847")
+- summary: brief description of what the job did and its outcome
+
+IMPORTANT: After calling cron_report, do NOT repeat or summarize the data
+in your text response. The tool renders a rich card UI automatically. Just
+confirm briefly, e.g. "Here are your recent cron runs."
+```
+
+## 3. Route AG-UI requests to the agent
+
+The AG-UI client targets this agent by sending the `X-OpenClaw-Agent-Id` header with each request. No static binding is required.
+
+### How it works
+
+The clawg-ui HTTP handler reads the header at request time:
+
+```
+X-OpenClaw-Agent-Id: cron-demo
+```
+
+This is passed to `resolveAgentRoute()` as the `accountId`, which matches the agent by ID. The header approach is flexible -- the same device can target different agents per request.
+
+### CopilotKit / Dojo client configuration
+
+In the Dojo app or any CopilotKit `HttpAgent` configuration, set the agent header:
+
+```typescript
+const agent = new HttpAgent({
+  url: "https://your-server/v1/clawg-ui",
+  headers: {
+    "Authorization": "Bearer <device-token>",
+    "X-OpenClaw-Agent-Id": "cron-demo",
+  },
+});
+```
+
+### Alternative: static binding
+
+If you prefer all clawg-ui traffic to route to this agent (no header needed):
+
+```json5
+{
+  "bindings": [
+    {
+      "agentId": "cron-demo",
+      "match": { "channel": "clawg-ui", "accountId": "*" }
+    }
+  ]
+}
+```
+
+## 4. Optional: identity linking for shared session context
+
+If you want the cron-demo agent to share session context with your identity on other channels (e.g. Telegram), add an identity link:
+
+```json5
+{
+  "session": {
+    "dmScope": "per-peer",
+    "identityLinks": {
+      "me": ["clawg-ui:<your-device-id>", "telegram:<your-telegram-id>"]
+    }
+  }
+}
+```
+
+This means the agent sees prior conversation history from linked channels, so it doesn't start with a blank slate.
+
+## 5. Verify
+
+Restart the gateway to pick up config changes, then send a request:
+
+```bash
+curl -X POST https://your-server/v1/clawg-ui \
+  -H "Authorization: Bearer <device-token>" \
+  -H "Accept: text/event-stream" \
+  -H "X-OpenClaw-Agent-Id: cron-demo" \
+  -d '{
+    "threadId": "test-1",
+    "messages": [{"role": "user", "content": "Show me the last 3 cron runs"}]
+  }'
+```
+
+Expected SSE event sequence:
+
+```
+RUN_STARTED
+  TOOL_CALL_START   { toolCallName: "cron_report" }
+  TOOL_CALL_ARGS    { delta: '{"runs": [...]}' }
+  TOOL_CALL_RESULT  { content: '{"a2ui_operations": [...]}' }
+  ACTIVITY_SNAPSHOT { activityType: "a2ui-surface", replace: true }
+  TOOL_CALL_END
+  TEXT_MESSAGE_START
+  TEXT_MESSAGE_CONTENT  { delta: "Here are your recent cron runs." }
+  TEXT_MESSAGE_END
+RUN_FINISHED
+```
+
+The Dojo client renders the `ACTIVITY_SNAPSHOT` as interactive cards with startedAt, duration, model, tokens, and summary fields.

--- a/examples/cron-report-tool.test.ts
+++ b/examples/cron-report-tool.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest";
+import { cronReportToolFactory } from "./cron-report-tool.js";
+
+describe("cronReportToolFactory", () => {
+  it("returns null when sessionKey is missing", () => {
+    expect(cronReportToolFactory({})).toBeNull();
+    expect(cronReportToolFactory({ sessionKey: undefined })).toBeNull();
+  });
+
+  it("returns a tool with correct name and parameters", () => {
+    const tool = cronReportToolFactory({ sessionKey: "test-session" });
+    expect(tool).not.toBeNull();
+    expect(tool!.name).toBe("cron_report");
+    expect(tool!.parameters.required).toContain("runs");
+  });
+
+  it("execute returns valid A2UI v0.9 JSON with 3 operations", async () => {
+    const tool = cronReportToolFactory({ sessionKey: "test-session" })!;
+    const runs = [
+      {
+        id: "run-1",
+        startedAt: "Apr 5, 10:30 AM",
+        duration: "2m 14s",
+        model: "claude-sonnet-4-6",
+        tokensUsed: "12,847",
+        summary: "All checks passed.",
+      },
+    ];
+
+    const result = await tool.execute("tc-1", { runs });
+    expect(result.content).toHaveLength(1);
+    expect(result.content[0].type).toBe("text");
+
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.a2ui_operations).toHaveLength(3);
+
+    const [create, update, data] = parsed.a2ui_operations;
+    expect(create.version).toBe("v0.9");
+    expect(create.createSurface.surfaceId).toBe("cron-report");
+    expect(update.updateComponents.surfaceId).toBe("cron-report");
+    expect(update.updateComponents.components).toBeDefined();
+    expect(data.updateDataModel.value.runs).toEqual(runs);
+  });
+});

--- a/examples/cron-report-tool.ts
+++ b/examples/cron-report-tool.ts
@@ -1,0 +1,162 @@
+/**
+ * Server-side `cron_report` tool that wraps cron job data in A2UI v0.9 schema.
+ *
+ * The agent calls this tool with an array of cron run objects. The execute
+ * method wraps them in a fixed A2UI v0.9 component tree (cards with
+ * startedAt, duration, model, tokensUsed, summary) and returns the result
+ * as JSON text.  The `handleToolResultPersist` hook in index.ts detects the
+ * A2UI wrapper and emits `ACTIVITY_SNAPSHOT` events automatically.
+ */
+
+const SURFACE_ID = "cron-report";
+const CATALOG_ID = "https://a2ui.org/specification/v0_9/basic_catalog.json";
+
+/**
+ * Fixed A2UI v0.9 component tree for the cron report card layout.
+ *
+ * Renders a horizontal list of cards.  Each card shows:
+ * - Top row: "Started" caption + start time heading
+ * - Divider
+ * - Model row: "Model" caption + model name
+ * - Metrics row: "Tokens" + count, "Duration" + time
+ * - Divider
+ * - Summary: caption + body text
+ */
+const CRON_REPORT_SCHEMA = [
+  {
+    id: "root",
+    component: "List",
+    children: { componentId: "run-card", path: "/runs" },
+    direction: "horizontal",
+    align: "start",
+  },
+  { id: "run-card", component: "Card", child: "run-col" },
+  {
+    id: "run-col",
+    component: "Column",
+    children: [
+      "time-row",
+      "divider-1",
+      "model-row",
+      "tokens-row",
+      "divider-2",
+      "summary-label",
+      "summary-text",
+    ],
+    align: "stretch",
+  },
+
+  {
+    id: "time-row",
+    component: "Row",
+    children: ["started-label", "started-value"],
+    justify: "spaceBetween",
+    align: "center",
+  },
+  { id: "started-label", component: "Text", text: "Started", variant: "caption" },
+  { id: "started-value", component: "Text", text: { path: "startedAt" }, variant: "h3" },
+
+  { id: "divider-1", component: "Divider" },
+
+  {
+    id: "model-row",
+    component: "Row",
+    children: ["model-label", "model-value"],
+    justify: "spaceBetween",
+    align: "center",
+  },
+  { id: "model-label", component: "Text", text: "Model", variant: "caption" },
+  { id: "model-value", component: "Text", text: { path: "model" }, variant: "body" },
+
+  {
+    id: "tokens-row",
+    component: "Row",
+    children: ["tokens-label", "tokens-value", "duration-label", "duration-value"],
+    justify: "spaceBetween",
+    align: "center",
+  },
+  { id: "tokens-label", component: "Text", text: "Tokens", variant: "caption" },
+  { id: "tokens-value", component: "Text", text: { path: "tokensUsed" }, variant: "body" },
+  { id: "duration-label", component: "Text", text: "Duration", variant: "caption" },
+  { id: "duration-value", component: "Text", text: { path: "duration" }, variant: "body" },
+
+  { id: "divider-2", component: "Divider" },
+
+  { id: "summary-label", component: "Text", text: "Summary", variant: "caption" },
+  { id: "summary-text", component: "Text", text: { path: "summary" }, variant: "body" },
+];
+
+interface CronRun {
+  id: string;
+  startedAt: string;
+  duration: string;
+  model: string;
+  tokensUsed: string;
+  summary: string;
+}
+
+/**
+ * Tool factory for the `cron_report` server-side tool.
+ *
+ * Returns the tool when a sessionKey is present (i.e. within an AG-UI
+ * request), or `null` otherwise.
+ */
+export function cronReportToolFactory(ctx: { sessionKey?: string }) {
+  if (!ctx.sessionKey) return null;
+
+  return {
+    name: "cron_report",
+    label: "Cron Report",
+    description:
+      "Display cron job run results as rich visual cards. Call this tool with an array of " +
+      "cron run objects. Each run must have: id (unique string), startedAt (readable date/time), " +
+      "duration (e.g. \"2m 14s\"), model (LLM model name), tokensUsed (formatted number string), " +
+      "and summary (free-text description of what the run did and its status).",
+    parameters: {
+      type: "object" as const,
+      properties: {
+        runs: {
+          type: "array" as const,
+          items: {
+            type: "object" as const,
+            properties: {
+              id: { type: "string" as const, description: "Unique run identifier" },
+              startedAt: { type: "string" as const, description: "When the run started, e.g. 'Apr 5, 10:30 AM'" },
+              duration: { type: "string" as const, description: "How long the run took, e.g. '2m 14s'" },
+              model: { type: "string" as const, description: "LLM model used, e.g. 'claude-sonnet-4-6'" },
+              tokensUsed: { type: "string" as const, description: "Total tokens consumed, e.g. '12,847'" },
+              summary: { type: "string" as const, description: "Free-text summary of what the job did and its outcome" },
+            },
+            required: ["id", "startedAt", "duration", "model", "tokensUsed", "summary"],
+          },
+        },
+      },
+      required: ["runs"],
+    },
+    async execute(_toolCallId: string, args: unknown) {
+      const { runs } = args as { runs: CronRun[] };
+
+      const a2uiResult = JSON.stringify({
+        a2ui_operations: [
+          {
+            version: "v0.9",
+            createSurface: { surfaceId: SURFACE_ID, catalogId: CATALOG_ID },
+          },
+          {
+            version: "v0.9",
+            updateComponents: { surfaceId: SURFACE_ID, components: CRON_REPORT_SCHEMA },
+          },
+          {
+            version: "v0.9",
+            updateDataModel: { surfaceId: SURFACE_ID, path: "/", value: { runs } },
+          },
+        ],
+      });
+
+      return {
+        content: [{ type: "text" as const, text: a2uiResult }],
+        details: { a2ui: true },
+      };
+    },
+  };
+}

--- a/index.ts
+++ b/index.ts
@@ -15,6 +15,12 @@ import {
   setClientToolCalled,
   setToolFiredInRun,
 } from "./src/tool-store.js";
+import {
+  extractToolResultText,
+  tryParseA2UIOperations,
+  groupBySurface,
+  A2UI_OPERATIONS_KEY,
+} from "./src/a2ui.js";
 
 // ---------------------------------------------------------------------------
 // Hook handlers — exported for testability
@@ -119,6 +125,14 @@ export function handleToolResultPersist(
     `[clawg-ui] tool_result_persist: writer=${writer ? "present" : "missing"}, toolCallId=${toolCallId ?? "none"}, messageId=${messageId ?? "none"}`,
   );
   if (writer && toolCallId && messageId) {
+    // Extract actual tool result text from event.message.content
+    const msg = (event as Record<string, unknown>).message as
+      | { content?: unknown }
+      | undefined;
+    const resultText = msg?.content
+      ? extractToolResultText(msg.content)
+      : "";
+
     console.log(
       `[clawg-ui] tool_result_persist: emitting TOOL_CALL_RESULT and TOOL_CALL_END`,
     );
@@ -126,8 +140,24 @@ export function handleToolResultPersist(
       type: EventType.TOOL_CALL_RESULT,
       toolCallId,
       messageId,
-      content: "",
+      content: resultText,
     });
+
+    // Detect A2UI and emit ACTIVITY_SNAPSHOT per surface
+    const a2uiOps = tryParseA2UIOperations(resultText);
+    if (a2uiOps) {
+      const groups = groupBySurface(a2uiOps);
+      for (const [surfaceId, ops] of groups) {
+        writer({
+          type: EventType.ACTIVITY_SNAPSHOT,
+          messageId: `a2ui-surface-${surfaceId}-${toolCallId}`,
+          activityType: "a2ui-surface",
+          content: { [A2UI_OPERATIONS_KEY]: ops },
+          replace: true,
+        });
+      }
+    }
+
     writer({
       type: EventType.TOOL_CALL_END,
       toolCallId,
@@ -149,6 +179,15 @@ const plugin: {
   register(api: OpenClawPluginApi) {
     api.registerChannel({ plugin: aguiChannelPlugin });
     api.registerTool(clawgUiToolFactory);
+    // Example tools (not published to npm — live in examples/)
+    import("./examples/cron-report-tool.js")
+      .then(({ cronReportToolFactory }) => {
+        api.registerTool(cronReportToolFactory, { name: "cron_report", optional: true });
+      })
+      .catch(() => {
+        // examples/ not available (npm install) — skip
+      });
+
     // Use registerPluginHttpRoute from plugin-sdk which writes directly to
     // the pinned HTTP route registry. api.registerHttpRoute writes to the
     // loader's private registry which is not the one the HTTP handler reads.

--- a/index.ts
+++ b/index.ts
@@ -13,7 +13,6 @@ import {
   popToolCallId,
   isClientTool,
   setClientToolCalled,
-  setToolFiredInRun,
 } from "./src/tool-store.js";
 import {
   extractToolResultText,
@@ -67,7 +66,6 @@ export function handleBeforeToolCall(
     toolCallId,
     toolCallName: event.toolName,
   });
-  setToolFiredInRun(sk);
   if (event.params && Object.keys(event.params).length > 0) {
     console.log(
       `[clawg-ui] before_tool_call: emitting TOOL_CALL_ARGS, params=${JSON.stringify(event.params)}`,

--- a/index.ts
+++ b/index.ts
@@ -186,16 +186,16 @@ const plugin: {
         // examples/ not available (npm install) — skip
       });
 
-    // Register HTTP route via gateway_start hook to ensure the pinned HTTP
-    // route registry is available (api.registerHttpRoute in register() runs
-    // before the registry is pinned, so routes are silently lost).
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- gateway_start not yet in SDK typings
-    (api.on as any)("gateway_start", () => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- auth/match not yet in SDK typings
-      (api.registerHttpRoute as (params: any) => void)({
+    // Use registerPluginHttpRoute from plugin-runtime which writes directly to
+    // the pinned HTTP route registry. api.registerHttpRoute writes to the
+    // loader's private registry which is not the one the HTTP handler reads.
+    // @ts-expect-error -- openclaw/plugin-sdk/plugin-runtime is not in local SDK typings but exists at runtime
+    import("openclaw/plugin-sdk/plugin-runtime").then((mod: any) => {
+      mod.registerPluginHttpRoute({
         path: "/v1/clawg-ui",
-        match: "exact",
         auth: "plugin",
+        match: "exact",
+        pluginId: "clawg-ui",
         handler: createAguiHttpHandler(api),
       });
     });

--- a/index.ts
+++ b/index.ts
@@ -149,11 +149,10 @@ const plugin: {
   register(api: OpenClawPluginApi) {
     api.registerChannel({ plugin: aguiChannelPlugin });
     api.registerTool(clawgUiToolFactory);
-    // Use registerPluginHttpRoute from plugin-runtime which writes directly to
+    // Use registerPluginHttpRoute from plugin-sdk which writes directly to
     // the pinned HTTP route registry. api.registerHttpRoute writes to the
     // loader's private registry which is not the one the HTTP handler reads.
-    // @ts-expect-error -- openclaw/plugin-sdk/plugin-runtime is not in local SDK typings but exists at runtime
-    import("openclaw/plugin-sdk/plugin-runtime").then((mod: any) => {
+    import("openclaw/plugin-sdk").then((mod: any) => {
       mod.registerPluginHttpRoute({
         path: "/v1/clawg-ui",
         auth: "plugin",

--- a/index.ts
+++ b/index.ts
@@ -186,15 +186,16 @@ const plugin: {
         // examples/ not available (npm install) — skip
       });
 
-    // Use registerPluginHttpRoute from plugin-sdk which writes directly to
-    // the pinned HTTP route registry. api.registerHttpRoute writes to the
-    // loader's private registry which is not the one the HTTP handler reads.
-    import("openclaw/plugin-sdk").then((mod: any) => {
-      mod.registerPluginHttpRoute({
+    // Register HTTP route via gateway_start hook to ensure the pinned HTTP
+    // route registry is available (api.registerHttpRoute in register() runs
+    // before the registry is pinned, so routes are silently lost).
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- gateway_start not yet in SDK typings
+    (api.on as any)("gateway_start", () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- auth/match not yet in SDK typings
+      (api.registerHttpRoute as (params: any) => void)({
         path: "/v1/clawg-ui",
-        auth: "plugin",
         match: "exact",
-        pluginId: "clawg-ui",
+        auth: "plugin",
         handler: createAguiHttpHandler(api),
       });
     });

--- a/index.ts
+++ b/index.ts
@@ -134,10 +134,13 @@ export function handleToolResultPersist(
     console.log(
       `[clawg-ui] tool_result_persist: emitting TOOL_CALL_RESULT and TOOL_CALL_END`,
     );
+    // Use a dedicated messageId for the tool result so it doesn't collide
+    // with the text message messageId. Tool events are linked via toolCallId.
+    const toolResultMessageId = `msg-tool-${toolCallId}`;
     writer({
       type: EventType.TOOL_CALL_RESULT,
       toolCallId,
-      messageId,
+      messageId: toolResultMessageId,
       content: resultText,
     });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contextableai/clawg-ui",
-  "version": "0.5.4",
+  "version": "0.6.0",
   "description": "AG-UI protocol channel plugin for OpenClaw — connect CopilotKit and AG-UI clients to your OpenClaw gateway",
   "type": "module",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "main": "./dist/index.js",
   "files": [
     "dist",
+    "!dist/examples",
     "openclaw.plugin.json"
   ],
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contextableai/clawg-ui",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "AG-UI protocol channel plugin for OpenClaw — connect CopilotKit and AG-UI clients to your OpenClaw gateway",
   "type": "module",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contextableai/clawg-ui",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "AG-UI protocol channel plugin for OpenClaw — connect CopilotKit and AG-UI clients to your OpenClaw gateway",
   "type": "module",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contextableai/clawg-ui",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "AG-UI protocol channel plugin for OpenClaw — connect CopilotKit and AG-UI clients to your OpenClaw gateway",
   "type": "module",
   "license": "MIT",

--- a/src/a2ui.test.ts
+++ b/src/a2ui.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect } from "vitest";
+import {
+  extractToolResultText,
+  tryParseA2UIOperations,
+  getOperationSurfaceId,
+  groupBySurface,
+} from "./a2ui.js";
+
+describe("extractToolResultText", () => {
+  it("joins text blocks", () => {
+    const content = [
+      { type: "text", text: "hello" },
+      { type: "text", text: "world" },
+    ];
+    expect(extractToolResultText(content)).toBe("hello\nworld");
+  });
+
+  it("ignores non-text blocks", () => {
+    const content = [
+      { type: "image", data: "..." },
+      { type: "text", text: "only text" },
+    ];
+    expect(extractToolResultText(content)).toBe("only text");
+  });
+
+  it("returns empty string for non-array", () => {
+    expect(extractToolResultText(null)).toBe("");
+    expect(extractToolResultText(undefined)).toBe("");
+    expect(extractToolResultText("string")).toBe("");
+    expect(extractToolResultText(42)).toBe("");
+  });
+
+  it("returns empty string for empty array", () => {
+    expect(extractToolResultText([])).toBe("");
+  });
+});
+
+describe("tryParseA2UIOperations", () => {
+  it("parses v0.9 wrapper with a2ui_operations key", () => {
+    const json = JSON.stringify({
+      a2ui_operations: [
+        { version: "v0.9", createSurface: { surfaceId: "s1" } },
+        { version: "v0.9", updateComponents: { surfaceId: "s1", components: [] } },
+      ],
+    });
+    const result = tryParseA2UIOperations(json);
+    expect(result).toHaveLength(2);
+    expect(result![0]).toHaveProperty("version", "v0.9");
+  });
+
+  it("returns null for non-A2UI JSON object", () => {
+    expect(tryParseA2UIOperations(JSON.stringify({ foo: "bar" }))).toBeNull();
+  });
+
+  it("returns null for plain text", () => {
+    expect(tryParseA2UIOperations("hello world")).toBeNull();
+  });
+
+  it("returns null for empty string", () => {
+    expect(tryParseA2UIOperations("")).toBeNull();
+  });
+
+  it("returns null for JSON array (not wrapper object)", () => {
+    expect(tryParseA2UIOperations(JSON.stringify([1, 2, 3]))).toBeNull();
+  });
+
+  it("returns null when a2ui_operations is empty array", () => {
+    expect(tryParseA2UIOperations(JSON.stringify({ a2ui_operations: [] }))).toBeNull();
+  });
+
+  it("returns null when a2ui_operations items lack version/op keys", () => {
+    expect(
+      tryParseA2UIOperations(JSON.stringify({ a2ui_operations: [{ random: true }] })),
+    ).toBeNull();
+  });
+});
+
+describe("getOperationSurfaceId", () => {
+  it("extracts surfaceId from createSurface", () => {
+    expect(
+      getOperationSurfaceId({ version: "v0.9", createSurface: { surfaceId: "my-surface" } }),
+    ).toBe("my-surface");
+  });
+
+  it("extracts surfaceId from updateComponents", () => {
+    expect(
+      getOperationSurfaceId({ version: "v0.9", updateComponents: { surfaceId: "s2", components: [] } }),
+    ).toBe("s2");
+  });
+
+  it("extracts surfaceId from updateDataModel", () => {
+    expect(
+      getOperationSurfaceId({ version: "v0.9", updateDataModel: { surfaceId: "s3", path: "/", value: {} } }),
+    ).toBe("s3");
+  });
+
+  it("extracts surfaceId from deleteSurface", () => {
+    expect(
+      getOperationSurfaceId({ version: "v0.9", deleteSurface: { surfaceId: "s4" } }),
+    ).toBe("s4");
+  });
+
+  it("returns null when no surfaceId present", () => {
+    expect(getOperationSurfaceId({ version: "v0.9" })).toBeNull();
+  });
+});
+
+describe("groupBySurface", () => {
+  it("groups operations by surfaceId", () => {
+    const ops = [
+      { version: "v0.9", createSurface: { surfaceId: "a" } },
+      { version: "v0.9", createSurface: { surfaceId: "b" } },
+      { version: "v0.9", updateComponents: { surfaceId: "a", components: [] } },
+    ];
+    const groups = groupBySurface(ops);
+    expect(groups.size).toBe(2);
+    expect(groups.get("a")).toHaveLength(2);
+    expect(groups.get("b")).toHaveLength(1);
+  });
+
+  it("uses 'default' for operations without surfaceId", () => {
+    const ops = [{ version: "v0.9" }];
+    const groups = groupBySurface(ops);
+    expect(groups.get("default")).toHaveLength(1);
+  });
+});

--- a/src/a2ui.ts
+++ b/src/a2ui.ts
@@ -1,0 +1,116 @@
+/**
+ * A2UI v0.9 detection utilities for tool results.
+ *
+ * Detects when a server-side tool returns A2UI JSON (the v0.9 wrapper format
+ * `{ "a2ui_operations": [...] }`) and provides helpers for grouping operations
+ * by surfaceId.
+ */
+
+export const A2UI_OPERATIONS_KEY = "a2ui_operations";
+
+/** v0.9 operation keys that identify an A2UI operation object. */
+const V09_KEYS = [
+  "createSurface",
+  "updateComponents",
+  "updateDataModel",
+  "deleteSurface",
+] as const;
+
+/**
+ * Extract concatenated text from a `tool_result_persist` event's
+ * `message.content` array.
+ *
+ * The OpenClaw hook provides `event.message` as a ToolResultMessage whose
+ * `.content` is `Array<{ type: "text", text: string } | ...>`.  We filter
+ * for text blocks and join them.
+ */
+export function extractToolResultText(content: unknown): string {
+  if (!Array.isArray(content)) return "";
+  const texts: string[] = [];
+  for (const block of content) {
+    if (
+      typeof block === "object" &&
+      block !== null &&
+      (block as Record<string, unknown>).type === "text" &&
+      typeof (block as Record<string, unknown>).text === "string"
+    ) {
+      texts.push((block as { text: string }).text);
+    }
+  }
+  return texts.join("\n");
+}
+
+/**
+ * Try to parse a string as A2UI v0.9 operations.
+ *
+ * Supports the v0.9 wrapper format: `{ "a2ui_operations": [...] }`
+ * Returns the operations array, or `null` if not valid A2UI JSON.
+ */
+export function tryParseA2UIOperations(
+  text: string,
+): Array<Record<string, unknown>> | null {
+  if (!text) return null;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    return null;
+  }
+
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    return null;
+  }
+
+  const wrapper = parsed as Record<string, unknown>;
+  const ops = wrapper[A2UI_OPERATIONS_KEY];
+  if (!Array.isArray(ops) || ops.length === 0) return null;
+
+  // Validate that at least the first item looks like an A2UI operation
+  const first = ops[0];
+  if (typeof first !== "object" || first === null) return null;
+  const hasVersionKey = "version" in first;
+  const hasOpKey = V09_KEYS.some((k) => k in first);
+  if (!hasVersionKey && !hasOpKey) return null;
+
+  return ops as Array<Record<string, unknown>>;
+}
+
+/**
+ * Extract `surfaceId` from a single A2UI v0.9 operation.
+ */
+export function getOperationSurfaceId(
+  op: Record<string, unknown>,
+): string | null {
+  for (const key of V09_KEYS) {
+    const inner = op[key];
+    if (
+      typeof inner === "object" &&
+      inner !== null &&
+      "surfaceId" in (inner as Record<string, unknown>)
+    ) {
+      return (inner as Record<string, unknown>).surfaceId as string;
+    }
+  }
+  return null;
+}
+
+/**
+ * Group operations by `surfaceId`.  Operations without a surfaceId are
+ * placed under the key `"default"`.
+ */
+export function groupBySurface(
+  ops: Array<Record<string, unknown>>,
+): Map<string, Array<Record<string, unknown>>> {
+  const groups = new Map<string, Array<Record<string, unknown>>>();
+  for (const op of ops) {
+    const sid = getOperationSurfaceId(op) ?? "default";
+    let list = groups.get(sid);
+    if (!list) {
+      list = [];
+      groups.set(sid, list);
+    }
+    list.push(op);
+  }
+  return groups;
+}

--- a/src/http-handler.test.ts
+++ b/src/http-handler.test.ts
@@ -470,15 +470,11 @@ describe("AG-UI HTTP handler", () => {
     expect(types).toContain(EventType.RUN_FINISHED);
   });
 
-  it("splits into a new run when text follows a tool call", async () => {
-    const { setToolFiredInRun } = await import("./tool-store.js");
-
+  it("keeps tool calls and text in a single run (no run splitting)", async () => {
     const rt = (fakeApi as any).runtime;
     rt.channel.reply.dispatchReplyFromConfig.mockImplementation(
-      async ({ dispatcher, ctx }: { dispatcher: any; ctx: any }) => {
-        // Simulate a server tool call having fired (flag set by before_tool_call hook)
-        setToolFiredInRun(ctx.SessionKey);
-        // Agent now sends text — should trigger run split
+      async ({ dispatcher }: { dispatcher: any }) => {
+        // Tool call followed by text — should stay in the same run
         dispatcher.sendBlockReply({ text: "Here is the result" });
         dispatcher.sendFinalReply({ text: "" });
         return { queuedFinal: true, counts: { tool: 1, block: 1, final: 1 } };
@@ -489,64 +485,8 @@ describe("AG-UI HTTP handler", () => {
     const req = createReq({
       headers: { authorization: `Bearer ${token}` },
       body: {
-        threadId: "t-split",
-        runId: "r-split",
-        messages: [{ role: "user", content: "Hello" }],
-      },
-    });
-    const res = createRes();
-    await handler(req, res);
-
-    const events = parseEvents(res._chunks);
-    const types = events.map((e) => e.type);
-
-    // Should have two RUN_STARTED and two RUN_FINISHED events
-    const runStarted = events.filter((e) => e.type === EventType.RUN_STARTED);
-    const runFinished = events.filter((e) => e.type === EventType.RUN_FINISHED);
-    expect(runStarted.length).toBe(2);
-    expect(runFinished.length).toBe(2);
-
-    // First run uses the original runId
-    expect(runStarted[0]?.runId).toBe("r-split");
-    // Second run uses a new runId
-    expect(runStarted[1]?.runId).not.toBe("r-split");
-    expect(typeof runStarted[1]?.runId).toBe("string");
-
-    // The first RUN_FINISHED ends the tool run (original runId)
-    expect(runFinished[0]?.runId).toBe("r-split");
-    // The second RUN_FINISHED ends the text run (new runId)
-    expect(runFinished[1]?.runId).toBe(runStarted[1]?.runId);
-
-    // Sequence: RUN_STARTED(tool) → RUN_FINISHED(tool) → RUN_STARTED(text) → TEXT_MESSAGE_START → ... → RUN_FINISHED(text)
-    const firstFinishIdx = types.indexOf(EventType.RUN_FINISHED);
-    const secondStartIdx = types.indexOf(EventType.RUN_STARTED, 1);
-    const textStartIdx = types.indexOf(EventType.TEXT_MESSAGE_START);
-    expect(firstFinishIdx).toBeLessThan(secondStartIdx);
-    expect(secondStartIdx).toBeLessThan(textStartIdx);
-
-    // Text message events should reference the new run's messageId
-    expect(types).toContain(EventType.TEXT_MESSAGE_START);
-    expect(types).toContain(EventType.TEXT_MESSAGE_CONTENT);
-    expect(types).toContain(EventType.TEXT_MESSAGE_END);
-  });
-
-  it("does not split run when no tool was called before text", async () => {
-    const rt = (fakeApi as any).runtime;
-    rt.channel.reply.dispatchReplyFromConfig.mockImplementation(
-      async ({ dispatcher }: { dispatcher: any }) => {
-        // No tool call — just text
-        dispatcher.sendBlockReply({ text: "Hello from agent" });
-        dispatcher.sendFinalReply({ text: "" });
-        return { queuedFinal: true, counts: { tool: 0, block: 1, final: 1 } };
-      },
-    );
-
-    const token = createDeviceToken(GATEWAY_SECRET, APPROVED_DEVICE_ID);
-    const req = createReq({
-      headers: { authorization: `Bearer ${token}` },
-      body: {
-        threadId: "t-nosplit",
-        runId: "r-nosplit",
+        threadId: "t-single",
+        runId: "r-single",
         messages: [{ role: "user", content: "Hello" }],
       },
     });
@@ -555,13 +495,18 @@ describe("AG-UI HTTP handler", () => {
 
     const events = parseEvents(res._chunks);
 
-    // Should have exactly one RUN_STARTED and one RUN_FINISHED
+    // Exactly one RUN_STARTED and one RUN_FINISHED — no splitting
     const runStarted = events.filter((e) => e.type === EventType.RUN_STARTED);
     const runFinished = events.filter((e) => e.type === EventType.RUN_FINISHED);
     expect(runStarted.length).toBe(1);
     expect(runFinished.length).toBe(1);
-    expect(runStarted[0]?.runId).toBe("r-nosplit");
-    expect(runFinished[0]?.runId).toBe("r-nosplit");
+    expect(runStarted[0]?.runId).toBe("r-single");
+    expect(runFinished[0]?.runId).toBe("r-single");
+
+    // Text events are present in the same run
+    expect(events.map((e) => e.type)).toContain(EventType.TEXT_MESSAGE_START);
+    expect(events.map((e) => e.type)).toContain(EventType.TEXT_MESSAGE_CONTENT);
+    expect(events.map((e) => e.type)).toContain(EventType.TEXT_MESSAGE_END);
   });
 
   it("includes tool messages in conversation context for new run", async () => {

--- a/src/http-handler.ts
+++ b/src/http-handler.ts
@@ -12,8 +12,6 @@ import {
   wasClientToolCalled,
   clearClientToolCalled,
   clearClientToolNames,
-  wasToolFiredInRun,
-  clearToolFiredInRun,
 } from "./tool-store.js";
 import { aguiChannelPlugin } from "./channel.js";
 import { resolveGatewaySecret } from "./gateway-secret.js";
@@ -417,40 +415,6 @@ export function createAguiHttpHandler(api: OpenClawPluginApi) {
       }
     };
 
-    // If a tool call was emitted in the current run, finish that run and start
-    // a fresh one for text messages. This keeps tool events and text events in
-    // separate runs per the AG-UI protocol.
-    const splitRunIfToolFired = () => {
-      if (!wasToolFiredInRun(sessionKey)) {
-        return;
-      }
-      // Close any open text message before ending the run
-      if (messageStarted) {
-        writeEvent({
-          type: EventType.TEXT_MESSAGE_END,
-          messageId: currentMessageId,
-          runId: currentRunId,
-        });
-        messageStarted = false;
-      }
-      // End the tool run
-      writeEvent({
-        type: EventType.RUN_FINISHED,
-        threadId,
-        runId: currentRunId,
-      });
-      // Start a new run for text messages
-      currentRunId = `clawg-ui-run-${randomUUID()}`;
-      currentMessageId = `msg-${randomUUID()}`;
-      messageStarted = false;
-      clearToolFiredInRun(sessionKey);
-      writeEvent({
-        type: EventType.RUN_STARTED,
-        threadId,
-        runId: currentRunId,
-      });
-    };
-
     // Handle client disconnect
     req.on("close", () => {
       closed = true;
@@ -546,8 +510,6 @@ export function createAguiHttpHandler(api: OpenClawPluginApi) {
           return false;
         }
 
-        splitRunIfToolFired();
-
         if (!messageStarted) {
           messageStarted = true;
           writeEvent({
@@ -574,8 +536,6 @@ export function createAguiHttpHandler(api: OpenClawPluginApi) {
         const text = wasClientToolCalled(sessionKey) ? "" : payload.text?.trim();
 
         if (text) {
-          splitRunIfToolFired();
-
           if (!messageStarted) {
             messageStarted = true;
             writeEvent({
@@ -658,7 +618,6 @@ export function createAguiHttpHandler(api: OpenClawPluginApi) {
       clearWriter(sessionKey);
       clearClientToolCalled(sessionKey);
       clearClientToolNames(sessionKey);
-      clearToolFiredInRun(sessionKey);
     }
   };
 }

--- a/src/tool-hooks.test.ts
+++ b/src/tool-hooks.test.ts
@@ -152,6 +152,81 @@ describe("Tool event hooks", () => {
   });
 
   // -------------------------------------------------------------------------
+  // A2UI detection
+  // -------------------------------------------------------------------------
+
+  describe("A2UI tool results", () => {
+    it("emits ACTIVITY_SNAPSHOT for A2UI tool results", () => {
+      handleBeforeToolCall(
+        { toolName: "cron_report", params: { runs: [] } },
+        { sessionKey: SESSION_KEY },
+      );
+
+      const toolCallId = mock.events[0].toolCallId;
+
+      const a2uiJson = JSON.stringify({
+        a2ui_operations: [
+          { version: "v0.9", createSurface: { surfaceId: "cron-report" } },
+          { version: "v0.9", updateComponents: { surfaceId: "cron-report", components: [] } },
+        ],
+      });
+
+      handleToolResultPersist(
+        { message: { content: [{ type: "text", text: a2uiJson }] } },
+        { sessionKey: SESSION_KEY },
+      );
+
+      // Events: START, ARGS, RESULT, ACTIVITY_SNAPSHOT, END
+      expect(mock.events).toHaveLength(5);
+      expect(mock.events[2].type).toBe(EventType.TOOL_CALL_RESULT);
+      expect(mock.events[2].content).toBe(a2uiJson);
+
+      expect(mock.events[3].type).toBe(EventType.ACTIVITY_SNAPSHOT);
+      expect(mock.events[3].activityType).toBe("a2ui-surface");
+      expect(mock.events[3].replace).toBe(true);
+      expect(mock.events[3].messageId).toContain("a2ui-surface-cron-report-");
+      expect(mock.events[3].messageId).toContain(toolCallId as string);
+
+      expect(mock.events[4].type).toBe(EventType.TOOL_CALL_END);
+    });
+
+    it("does not emit ACTIVITY_SNAPSHOT for non-A2UI results", () => {
+      handleBeforeToolCall(
+        { toolName: "search_db", params: { q: "test" } },
+        { sessionKey: SESSION_KEY },
+      );
+
+      handleToolResultPersist(
+        { message: { content: [{ type: "text", text: "plain result" }] } },
+        { sessionKey: SESSION_KEY },
+      );
+
+      // Events: START, ARGS, RESULT, END (no ACTIVITY_SNAPSHOT)
+      expect(mock.events).toHaveLength(4);
+      expect(mock.events[2].type).toBe(EventType.TOOL_CALL_RESULT);
+      expect(mock.events[2].content).toBe("plain result");
+      expect(mock.events[3].type).toBe(EventType.TOOL_CALL_END);
+    });
+
+    it("populates TOOL_CALL_RESULT content from event.message", () => {
+      handleBeforeToolCall(
+        { toolName: "my_tool", params: {} },
+        { sessionKey: SESSION_KEY },
+      );
+
+      handleToolResultPersist(
+        { message: { content: [{ type: "text", text: "actual content" }] } },
+        { sessionKey: SESSION_KEY },
+      );
+
+      const resultEvent = mock.events.find(
+        (e) => e.type === EventType.TOOL_CALL_RESULT,
+      );
+      expect(resultEvent?.content).toBe("actual content");
+    });
+  });
+
+  // -------------------------------------------------------------------------
   // Edge cases
   // -------------------------------------------------------------------------
 

--- a/src/tool-hooks.test.ts
+++ b/src/tool-hooks.test.ts
@@ -10,8 +10,6 @@ import {
   clearWriter,
   markClientToolNames,
   clearClientToolNames,
-  clearToolFiredInRun,
-  wasToolFiredInRun,
 } from "./tool-store.js";
 import {
   handleBeforeToolCall,
@@ -47,7 +45,6 @@ describe("Tool event hooks", () => {
   afterEach(() => {
     clearWriter(SESSION_KEY);
     clearClientToolNames(SESSION_KEY);
-    clearToolFiredInRun(SESSION_KEY);
   });
 
   // -------------------------------------------------------------------------
@@ -100,16 +97,6 @@ describe("Tool event hooks", () => {
       expect(mock.events[1].type).toBe(EventType.TOOL_CALL_END);
     });
 
-    it("sets toolFiredInRun flag", () => {
-      expect(wasToolFiredInRun(SESSION_KEY)).toBe(false);
-
-      handleBeforeToolCall(
-        { toolName: "get_weather", params: { city: "Tokyo" } },
-        { sessionKey: SESSION_KEY },
-      );
-
-      expect(wasToolFiredInRun(SESSION_KEY)).toBe(true);
-    });
   });
 
   // -------------------------------------------------------------------------

--- a/src/tool-hooks.test.ts
+++ b/src/tool-hooks.test.ts
@@ -125,7 +125,7 @@ describe("Tool event hooks", () => {
       expect(mock.events).toHaveLength(4);
       expect(mock.events[2].type).toBe(EventType.TOOL_CALL_RESULT);
       expect(mock.events[2].toolCallId).toBe(toolCallId);
-      expect(mock.events[2].messageId).toBe("msg-001");
+      expect(mock.events[2].messageId).toBe(`msg-tool-${toolCallId}`);
       expect(mock.events[3].type).toBe(EventType.TOOL_CALL_END);
       expect(mock.events[3].toolCallId).toBe(toolCallId);
     });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,6 @@
     "declaration": true,
     "types": ["node"]
   },
-  "include": ["index.ts", "src"],
+  "include": ["index.ts", "src", "examples"],
   "exclude": ["**/*.test.ts"]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,6 +2,6 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
-    include: ["src/**/*.test.ts"],
+    include: ["src/**/*.test.ts", "examples/**/*.test.ts"],
   },
 });


### PR DESCRIPTION
## Summary

- **A2UI v0.9 support** — detect `{ a2ui_operations: [...] }` in server-side tool results and emit `ACTIVITY_SNAPSHOT` events over AG-UI SSE. Enables rich generative UI rendering in CopilotKit clients.
- **`cron_report` example tool** — server-side tool that wraps cron job data in A2UI v0.9 card layout. Registered as `optional: true`, scoped per-agent via `tools.alsoAllow`.
- **CopilotKit single-run fix** — removed run splitting (`splitRunIfToolFired`) that caused follow-up text to be lost after tool calls.
- **`TOOL_CALL_RESULT` content** — now populated with actual tool result text (was `""`).
- **`messageId` collision fix** — tool results and text messages no longer share the same messageId.
- **HTTP route registration** — restored v0.5.4 `registerPluginHttpRoute` pattern after `gateway_start` approach caused 404s.

## Test plan

- [x] `pnpm test` — all 70 tests pass (+ 13 skipped integration tests)
- [x] `pnpm build` — clean compilation
- [x] `pnpm pack --dry-run` — `dist/examples/` excluded from npm package
- [ ] Deploy to server, verify `ACTIVITY_SNAPSHOT` events in SSE stream after server tool call
- [ ] Verify CopilotKit Dojo renders A2UI cards from `cron_report` tool
- [ ] Verify text messages display after tool calls (no run splitting)

🤖 Generated with [Claude Code](https://claude.com/claude-code)