### PR TITLE
fix: resolve gateway secret from OpenClaw credentials store

### DIFF
--- a/src/gateway-secret.ts
+++ b/src/gateway-secret.ts
@@ -1,7 +1,16 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
 
 /**
  * Resolve the gateway HMAC secret from config or environment variables.
+ *
+ * Priority:
+ *   1. Plugin config  (gateway.auth.token)
+ *   2. OPENCLAW_GATEWAY_TOKEN env var
+ *   3. CLAWDBOT_GATEWAY_TOKEN env var
+ *   4. OpenClaw credentials store  (<state_dir>/credentials/gateway_token)
+ *   5. null  → caller returns 500 "Gateway not configured"
  *
  * This lives in its own module so that the HTTP handler file contains zero
  * `process.env` references — plugin security scanners flag "env access +
@@ -16,5 +25,20 @@ export function resolveGatewaySecret(api: OpenClawPluginApi): string | null {
   if (typeof secret === "string" && secret) {
     return secret;
   }
+
+  // Fallback: read from OpenClaw credentials store.
+  // Avoids requiring users to duplicate the gateway token in launchd env or
+  // shell profile — the credentials store is the canonical location on local installs.
+  try {
+    const stateDir = api.runtime.state.resolveStateDir();
+    const credPath = join(stateDir, "credentials", "gateway_token");
+    const token = readFileSync(credPath, "utf-8").trim();
+    if (token) {
+      return token;
+    }
+  } catch {
+    // File not found or unreadable — fall through
+  }
+
   return null;
 }


### PR DESCRIPTION
## Problem

On local installs where OpenClaw manages credentials via its credentials store (e.g. `~/.openclaw/credentials/gateway_token`), `resolveGatewaySecret()` returns `null` because it only checks plugin config and env vars. This causes `/v1/clawg-ui` to return:

```json
{"error":{"message":"Gateway not configured","type":"server_error"}}
```

This is common when the gateway runs as a launchd agent — the HMAC secret exists in the credentials store but is not duplicated into the process environment.

## Fix

Add a 4th fallback that reads `<state_dir>/credentials/gateway_token` using `api.runtime.state.resolveStateDir()`. If the file is missing or unreadable, it silently falls through — no new failure modes.

**Priority order (unchanged for existing sources):**
1. Plugin config (`gateway.auth.token`)
2. `OPENCLAW_GATEWAY_TOKEN` env var
3. `CLAWDBOT_GATEWAY_TOKEN` env var
4. *(new)* OpenClaw credentials store (`<state_dir>/credentials/gateway_token`)
5. `null` → 500 Gateway not configured

No config schema changes. Narrow, backward-compatible fix.