### PR TITLE
Add reasoning and step reporting event surfacing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,13 @@
 ## Unreleased
 
 ### Added
+- **Reasoning event surfacing** — emit AG-UI `REASONING_START`, `REASONING_MESSAGE_START/CONTENT/END`, `REASONING_END` events when the agent streams reasoning content (extended thinking). Requires models with thinking enabled (e.g. Claude with `thinkingDefault`, OpenAI o-series). On by default; disable via `surfaceReasoning: false` in channel defaults.
+- **Step reporting** — emit AG-UI `STEP_STARTED` / `STEP_FINISHED` events from OpenClaw's `onItemEvent` callback, giving CopilotKit clients visibility into multi-step agent progress. On by default; disable via `surfaceSteps: false` in channel defaults.
+- New channel defaults: `surfaceReasoning: true`, `surfaceSteps: true`
 - **`X-OpenClaw-Session-Key` header for per-user session isolation** — when present, the validated header value is composed under the route-derived session key as `<route.sessionKey>[:user:<header>][:thread:<threadId>]`. The header subdivides the route scope and never replaces it, enabling multi-user web apps (e.g. CopilotKit deployments where one AG-UI client is shared across authenticated users) to keep per-user conversation history isolated. Treat as a trusted-proxy-only header (analogous to `X-Forwarded-For`) — see the new "Session isolation" section in the README. Values are validated for length (1–256), charset (`[A-Za-z0-9._@:-]`), and path-traversal sequences; invalid values return `400 invalid_request_error` before the agent is dispatched. Thanks to @mikehole for the contribution (#22).
+
+### Changed
+- Bumped `@ag-ui/core` and `@ag-ui/encoder` from `^0.0.43` to `^0.0.52` — uses new `REASONING_*` events (the old `THINKING_*` events are deprecated and slated for removal in AG-UI v1.0.0)
 
 ## 0.6.4 (2026-04-17)
 

--- a/package.json
+++ b/package.json
@@ -28,8 +28,8 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@ag-ui/core": "^0.0.43",
-    "@ag-ui/encoder": "^0.0.43"
+    "@ag-ui/core": "^0.0.52",
+    "@ag-ui/encoder": "^0.0.52"
   },
   "peerDependencies": {
     "openclaw": "*"
@@ -54,7 +54,9 @@
       "order": 90,
       "defaults": {
         "blockStreaming": true,
-        "chunkMode": "newline"
+        "chunkMode": "newline",
+        "surfaceReasoning": true,
+        "surfaceSteps": true
       }
     },
     "install": {

--- a/src/http-handler.test.ts
+++ b/src/http-handler.test.ts
@@ -509,6 +509,199 @@ describe("AG-UI HTTP handler", () => {
     expect(events.map((e) => e.type)).toContain(EventType.TEXT_MESSAGE_END);
   });
 
+  // -------------------------------------------------------------------------
+  // Reasoning events
+  // -------------------------------------------------------------------------
+
+  it("emits REASONING events when onReasoningStream/onReasoningEnd are invoked", async () => {
+    const rt = (fakeApi as any).runtime;
+    rt.channel.reply.dispatchReplyFromConfig.mockImplementation(
+      async ({ dispatcher, replyOptions }: { dispatcher: any; replyOptions: any }) => {
+        // Simulate reasoning stream
+        replyOptions.onReasoningStream({ text: "Let me think..." });
+        replyOptions.onReasoningStream({ text: "The answer is 42." });
+        replyOptions.onReasoningEnd();
+        // Then final text
+        dispatcher.sendFinalReply({ text: "The answer is 42." });
+        return { queuedFinal: true, counts: { tool: 0, block: 0, final: 1 } };
+      },
+    );
+
+    const token = createDeviceToken(GATEWAY_SECRET, APPROVED_DEVICE_ID);
+    const req = createReq({
+      headers: { authorization: `Bearer ${token}` },
+      body: {
+        threadId: "t-reason",
+        runId: "r-reason",
+        messages: [{ role: "user", content: "Think carefully" }],
+      },
+    });
+    const res = createRes();
+    await handler(req, res);
+
+    const events = parseEvents(res._chunks);
+    const types = events.map((e) => e.type);
+
+    // Reasoning events should appear
+    expect(types).toContain(EventType.REASONING_START);
+    expect(types).toContain(EventType.REASONING_MESSAGE_START);
+    expect(types).toContain(EventType.REASONING_MESSAGE_CONTENT);
+    expect(types).toContain(EventType.REASONING_MESSAGE_END);
+    expect(types).toContain(EventType.REASONING_END);
+
+    // Reasoning message start should have role: "reasoning"
+    const reasonStart = events.find((e) => e.type === EventType.REASONING_MESSAGE_START);
+    expect(reasonStart?.role).toBe("reasoning");
+
+    // Two content deltas
+    const reasonContent = events.filter((e) => e.type === EventType.REASONING_MESSAGE_CONTENT);
+    expect(reasonContent).toHaveLength(2);
+    expect(reasonContent[0]?.delta).toBe("Let me think...");
+    expect(reasonContent[1]?.delta).toBe("The answer is 42.");
+
+    // All reasoning events share the same messageId
+    const reasoningEvents = events.filter(
+      (e) => typeof e.type === "string" && (e.type as string).startsWith("REASONING_"),
+    );
+    const messageIds = new Set(reasoningEvents.map((e) => e.messageId));
+    expect(messageIds.size).toBe(1);
+
+    // Reasoning messageId differs from text messageId
+    const textStart = events.find((e) => e.type === EventType.TEXT_MESSAGE_START);
+    expect(textStart?.messageId).not.toBe(reasoningEvents[0]?.messageId);
+
+    // Text message still present after reasoning
+    expect(types).toContain(EventType.TEXT_MESSAGE_START);
+    expect(types).toContain(EventType.RUN_FINISHED);
+  });
+
+  it("does not emit REASONING events when no reasoning stream fires", async () => {
+    const rt = (fakeApi as any).runtime;
+    rt.channel.reply.dispatchReplyFromConfig.mockImplementation(
+      async ({ dispatcher }: { dispatcher: any }) => {
+        dispatcher.sendFinalReply({ text: "Just text." });
+        return { queuedFinal: true, counts: { tool: 0, block: 0, final: 1 } };
+      },
+    );
+
+    const token = createDeviceToken(GATEWAY_SECRET, APPROVED_DEVICE_ID);
+    const req = createReq({
+      headers: { authorization: `Bearer ${token}` },
+      body: {
+        threadId: "t-noreason",
+        runId: "r-noreason",
+        messages: [{ role: "user", content: "Hello" }],
+      },
+    });
+    const res = createRes();
+    await handler(req, res);
+
+    const events = parseEvents(res._chunks);
+    const types = events.map((e) => e.type);
+
+    expect(types).not.toContain(EventType.REASONING_START);
+    expect(types).not.toContain(EventType.REASONING_MESSAGE_START);
+  });
+
+  it("auto-closes reasoning if sendFinalReply fires before onReasoningEnd", async () => {
+    const rt = (fakeApi as any).runtime;
+    rt.channel.reply.dispatchReplyFromConfig.mockImplementation(
+      async ({ dispatcher, replyOptions }: { dispatcher: any; replyOptions: any }) => {
+        replyOptions.onReasoningStream({ text: "Thinking..." });
+        // No onReasoningEnd call — sendFinalReply should close it
+        dispatcher.sendFinalReply({ text: "Done." });
+        return { queuedFinal: true, counts: { tool: 0, block: 0, final: 1 } };
+      },
+    );
+
+    const token = createDeviceToken(GATEWAY_SECRET, APPROVED_DEVICE_ID);
+    const req = createReq({
+      headers: { authorization: `Bearer ${token}` },
+      body: {
+        threadId: "t-autoclose",
+        runId: "r-autoclose",
+        messages: [{ role: "user", content: "Think" }],
+      },
+    });
+    const res = createRes();
+    await handler(req, res);
+
+    const events = parseEvents(res._chunks);
+    const types = events.map((e) => e.type);
+
+    // Reasoning should be properly closed even without explicit onReasoningEnd
+    expect(types).toContain(EventType.REASONING_START);
+    expect(types).toContain(EventType.REASONING_MESSAGE_END);
+    expect(types).toContain(EventType.REASONING_END);
+    expect(types).toContain(EventType.RUN_FINISHED);
+  });
+
+  // -------------------------------------------------------------------------
+  // Step events
+  // -------------------------------------------------------------------------
+
+  it("emits STEP_STARTED and STEP_FINISHED from onItemEvent", async () => {
+    const rt = (fakeApi as any).runtime;
+    rt.channel.reply.dispatchReplyFromConfig.mockImplementation(
+      async ({ dispatcher, replyOptions }: { dispatcher: any; replyOptions: any }) => {
+        replyOptions.onItemEvent({ itemId: "step-1", phase: "started", title: "Searching" });
+        replyOptions.onItemEvent({ itemId: "step-1", phase: "completed", title: "Searching" });
+        dispatcher.sendFinalReply({ text: "Found it." });
+        return { queuedFinal: true, counts: { tool: 0, block: 0, final: 1 } };
+      },
+    );
+
+    const token = createDeviceToken(GATEWAY_SECRET, APPROVED_DEVICE_ID);
+    const req = createReq({
+      headers: { authorization: `Bearer ${token}` },
+      body: {
+        threadId: "t-step",
+        runId: "r-step",
+        messages: [{ role: "user", content: "Search" }],
+      },
+    });
+    const res = createRes();
+    await handler(req, res);
+
+    const events = parseEvents(res._chunks);
+    const types = events.map((e) => e.type);
+
+    expect(types).toContain(EventType.STEP_STARTED);
+    expect(types).toContain(EventType.STEP_FINISHED);
+
+    const stepStart = events.find((e) => e.type === EventType.STEP_STARTED);
+    expect(stepStart?.stepName).toBe("Searching");
+  });
+
+  it("deduplicates STEP_STARTED for the same itemId", async () => {
+    const rt = (fakeApi as any).runtime;
+    rt.channel.reply.dispatchReplyFromConfig.mockImplementation(
+      async ({ dispatcher, replyOptions }: { dispatcher: any; replyOptions: any }) => {
+        replyOptions.onItemEvent({ itemId: "s1", phase: "started", title: "Step A" });
+        replyOptions.onItemEvent({ itemId: "s1", phase: "started", title: "Step A" }); // duplicate
+        replyOptions.onItemEvent({ itemId: "s1", phase: "completed", title: "Step A" });
+        dispatcher.sendFinalReply({ text: "Done." });
+        return { queuedFinal: true, counts: { tool: 0, block: 0, final: 1 } };
+      },
+    );
+
+    const token = createDeviceToken(GATEWAY_SECRET, APPROVED_DEVICE_ID);
+    const req = createReq({
+      headers: { authorization: `Bearer ${token}` },
+      body: {
+        threadId: "t-dedup",
+        runId: "r-dedup",
+        messages: [{ role: "user", content: "Go" }],
+      },
+    });
+    const res = createRes();
+    await handler(req, res);
+
+    const events = parseEvents(res._chunks);
+    const stepStarts = events.filter((e) => e.type === EventType.STEP_STARTED);
+    expect(stepStarts).toHaveLength(1);
+  });
+
   it("includes tool messages in conversation context for new run", async () => {
     const token = createDeviceToken(GATEWAY_SECRET, APPROVED_DEVICE_ID);
     const req = createReq({

--- a/src/http-handler.ts
+++ b/src/http-handler.ts
@@ -448,6 +448,37 @@ export function createAguiHttpHandler(api: OpenClawPluginApi) {
     let messageStarted = false;
     let currentRunId = runId;
 
+    // Reasoning & step reporting config (default on, opt-out via channel defaults)
+    const channelDefaults = (cfg as Record<string, unknown>).channels as
+      | Record<string, { defaults?: Record<string, unknown> }>
+      | undefined;
+    const clawgDefaults = channelDefaults?.["clawg-ui"]?.defaults ?? {};
+    const surfaceReasoning = clawgDefaults.surfaceReasoning !== false;
+    const surfaceSteps = clawgDefaults.surfaceSteps !== false;
+
+    // Reasoning state
+    let reasoningMessageId: string | null = null;
+    let reasoningStarted = false;
+
+    // Step reporting state
+    const activeSteps = new Set<string>();
+
+    // Close any open reasoning block (called before RUN_FINISHED)
+    const closeReasoningIfOpen = () => {
+      if (reasoningStarted && reasoningMessageId) {
+        writeEvent({
+          type: EventType.REASONING_MESSAGE_END,
+          messageId: reasoningMessageId,
+        });
+        writeEvent({
+          type: EventType.REASONING_END,
+          messageId: reasoningMessageId,
+        });
+        reasoningStarted = false;
+        reasoningMessageId = null;
+      }
+    };
+
     const writeEvent = (event: { type: EventType } & Record<string, unknown>) => {
       if (closed) {
         return;
@@ -601,6 +632,7 @@ export function createAguiHttpHandler(api: OpenClawPluginApi) {
           });
         }
         // End the message and run
+        closeReasoningIfOpen();
         if (messageStarted) {
           writeEvent({
             type: EventType.TEXT_MESSAGE_END,
@@ -633,12 +665,84 @@ export function createAguiHttpHandler(api: OpenClawPluginApi) {
           runId,
           abortSignal: abortController.signal,
           disableBlockStreaming: false,
+          ...(surfaceReasoning ? { streamReasoning: true } : {}),
           onAgentRunStart: () => {},
+          ...(surfaceReasoning
+            ? {
+                onReasoningStream: (payload: { text?: string }) => {
+                  if (closed) return;
+                  const text = payload.text;
+                  if (!text) return;
+
+                  if (!reasoningStarted) {
+                    reasoningStarted = true;
+                    reasoningMessageId = `reason-${randomUUID()}`;
+                    writeEvent({
+                      type: EventType.REASONING_START,
+                      messageId: reasoningMessageId,
+                    });
+                    writeEvent({
+                      type: EventType.REASONING_MESSAGE_START,
+                      messageId: reasoningMessageId,
+                      role: "reasoning",
+                    });
+                  }
+                  writeEvent({
+                    type: EventType.REASONING_MESSAGE_CONTENT,
+                    messageId: reasoningMessageId,
+                    delta: text,
+                  });
+                },
+                onReasoningEnd: () => {
+                  if (closed || !reasoningStarted) return;
+                  writeEvent({
+                    type: EventType.REASONING_MESSAGE_END,
+                    messageId: reasoningMessageId,
+                  });
+                  writeEvent({
+                    type: EventType.REASONING_END,
+                    messageId: reasoningMessageId,
+                  });
+                  reasoningStarted = false;
+                  reasoningMessageId = null;
+                },
+              }
+            : {}),
+          ...(surfaceSteps
+            ? {
+                onItemEvent: (item: {
+                  itemId?: string;
+                  phase?: string;
+                  title?: string;
+                }) => {
+                  if (closed) return;
+                  const itemId = item.itemId;
+                  if (!itemId) return;
+                  if (item.phase === "started" && !activeSteps.has(itemId)) {
+                    activeSteps.add(itemId);
+                    writeEvent({
+                      type: EventType.STEP_STARTED,
+                      stepName: item.title ?? itemId,
+                    });
+                  } else if (
+                    (item.phase === "completed" || item.phase === "failed") &&
+                    activeSteps.has(itemId)
+                  ) {
+                    activeSteps.delete(itemId);
+                    writeEvent({
+                      type: EventType.STEP_FINISHED,
+                      stepName: item.title ?? itemId,
+                    });
+                  }
+                },
+              }
+            : {}),
         },
       });
 
       // If the dispatcher's final reply didn't close the stream, close it now
       if (!closed) {
+        closeReasoningIfOpen();
         if (messageStarted) {
           writeEvent({
             type: EventType.TEXT_MESSAGE_END,


### PR DESCRIPTION
## Summary

- **Reasoning events** — emit `REASONING_START`, `REASONING_MESSAGE_START/CONTENT/END`, `REASONING_END` when the agent streams thinking content. Uses `onReasoningStream`/`onReasoningEnd` callbacks from OpenClaw's reply pipeline.
- **Step reporting** — emit `STEP_STARTED`/`STEP_FINISHED` from `onItemEvent`, giving CopilotKit clients visibility into multi-step agent progress.
- **Bumped `@ag-ui/core` to `^0.0.52`** — uses new `REASONING_*` events (THINKING is deprecated, removed in AG-UI v1.0.0).
- **Default on**, opt-out via `surfaceReasoning: false` / `surfaceSteps: false` in channel defaults.
- Auto-closes open reasoning blocks before `RUN_FINISHED` for robustness.

## Notes from rebase onto `main` (was: `feat/a2ui-support`)

- **Type fix**: `onItemEvent` callback parameter was over-narrowed (`itemId: string`, `phase: string`). Loosened to optional to match openclaw's `GetReplyOptions` signature; null-check applied inside.
- **Lockfile removed**: the original branch added a brand-new `pnpm-lock.yaml` (7241 lines). Tracked separately — see follow-up PR.
- **CHANGELOG**: queued under `## Unreleased` alongside the `X-OpenClaw-Session-Key` entry. Version in `package.json` left at `0.6.4` — bumped at release time.

## Test plan

- [x] `pnpm test` — 92 tests pass (5 new: reasoning flow, no-reasoning, auto-close, step events, step dedup)
- [x] `pnpm build` — clean compile (after type fix and rebase pulled in OpenClaw 2026.4.16 plugin-sdk compat from `main`)
- [ ] Deploy with reasoning-enabled model, verify `REASONING_*` events in SSE stream
- [ ] Multi-step agent task: verify `STEP_STARTED`/`STEP_FINISHED` in SSE stream
- [ ] Dojo client: reasoning renders as expandable thinking block

🤖 Generated with [Claude Code](https://claude.com/claude-code)