### PR TITLE
Compat with OpenClaw 2026.4.16 plugin-sdk API (0.6.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.6.4 (2026-04-17)
+
+### Changed
+- **Compat with OpenClaw 2026.4.16 plugin-sdk API:**
+  - `upsertPairingRequest` now requires `accountId` — pass `"default"` to match `src/channel.ts`.
+  - `ChatType` literal `"dm"` renamed to `"direct"` for `resolveAgentRoute` peer kinds.
+  - `ReplyDispatcher` gained required `getFailedCounts` and `markComplete` members (no-op stubs — clawg-ui doesn't track retries or typing indicators).
+  - `openclaw/plugin-sdk/plugin-runtime` is now a typed public subpath; removed the `@ts-expect-error` suppression in `index.ts`.
+
+### Fixed
+- Two `src/integration.test.ts` cases (`rejects missing user message with 400`, `rejects empty messages array with 400`) expected HTTP 400 but the handler has returned `200` with an empty SSE run since commit `e3a88c8` (AG-UI protocol compliance for init/sync). Tests now match the current protocol-compliant behavior.
+
 ## 0.6.3 (2026-04-07)
 
 ### Added

--- a/index.ts
+++ b/index.ts
@@ -192,7 +192,6 @@ const plugin: {
     // Use registerPluginHttpRoute from plugin-runtime which writes directly to
     // the pinned HTTP route registry. api.registerHttpRoute writes to the
     // loader's private registry which is not the one the HTTP handler reads.
-    // @ts-expect-error -- openclaw/plugin-sdk/plugin-runtime is not in local SDK typings but exists at runtime
     import("openclaw/plugin-sdk/plugin-runtime").then((mod: any) => {
       mod.registerPluginHttpRoute({
         path: "/v1/clawg-ui",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@contextableai/clawg-ui",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "AG-UI protocol channel plugin for OpenClaw — connect CopilotKit and AG-UI clients to your OpenClaw gateway",
   "type": "module",
   "license": "MIT",

--- a/src/http-handler.test.ts
+++ b/src/http-handler.test.ts
@@ -596,7 +596,7 @@ describe("AG-UI HTTP handler", () => {
     expect(rt.channel.routing.resolveAgentRoute).toHaveBeenCalledWith(
       expect.objectContaining({
         channel: "clawg-ui",
-        peer: { kind: "dm", id: APPROVED_DEVICE_ID },
+        peer: { kind: "direct", id: APPROVED_DEVICE_ID },
       }),
     );
   });

--- a/src/http-handler.ts
+++ b/src/http-handler.ts
@@ -236,6 +236,7 @@ export function createAguiHttpHandler(api: OpenClawPluginApi) {
       // Add to pending via OpenClaw pairing API - returns a pairing code for approval
       const { code: pairingCode } = await runtime.channel.pairing.upsertPairingRequest({
         channel: "clawg-ui",
+        accountId: "default",
         id: deviceId,
         pairingAdapter: aguiChannelPlugin.pairing,
       });
@@ -381,7 +382,7 @@ export function createAguiHttpHandler(api: OpenClawPluginApi) {
     const route = runtime.channel.routing.resolveAgentRoute({
       cfg,
       channel: "clawg-ui",
-      peer: { kind: "dm", id: deviceId },
+      peer: { kind: "direct", id: deviceId },
       accountId: agentIdHeader,
     });
 
@@ -572,6 +573,8 @@ export function createAguiHttpHandler(api: OpenClawPluginApi) {
       },
       waitForIdle: () => Promise.resolve(),
       getQueuedCounts: () => ({ tool: 0, block: 0, final: 0 }),
+      getFailedCounts: () => ({ tool: 0, block: 0, final: 0 }),
+      markComplete: () => {},
     };
 
     // Dispatch the inbound message — this triggers the agent run

--- a/src/integration.test.ts
+++ b/src/integration.test.ts
@@ -131,24 +131,30 @@ describeIntegration("clawg-ui integration", () => {
 
   // -- Validation --------------------------------------------------------
 
-  it("rejects missing user message with 400", async () => {
+  it("returns empty SSE run when no user/tool messages (AG-UI init/sync)", async () => {
     const res = await postRun({
       threadId: "int-test",
       runId: "run-1",
       messages: [{ role: "system", content: "sys" }],
     });
-    expect(res.status).toBe(400);
-    const body = await res.json();
-    expect(body.error.type).toBe("invalid_request_error");
+    expect(res.status).toBe(200);
+    const events = await collectEvents(res);
+    const types = events.map((e) => e.type);
+    expect(types).toContain(EventType.RUN_STARTED);
+    expect(types).toContain(EventType.RUN_FINISHED);
   });
 
-  it("rejects empty messages array with 400", async () => {
+  it("returns empty SSE run when messages array is empty (AG-UI init/sync)", async () => {
     const res = await postRun({
       threadId: "int-test",
       runId: "run-1",
       messages: [],
     });
-    expect(res.status).toBe(400);
+    expect(res.status).toBe(200);
+    const events = await collectEvents(res);
+    const types = events.map((e) => e.type);
+    expect(types).toContain(EventType.RUN_STARTED);
+    expect(types).toContain(EventType.RUN_FINISHED);
   });
 
   // -- SSE stream --------------------------------------------------------


### PR DESCRIPTION
## Summary

- Migrate to OpenClaw `2026.4.16` plugin-sdk surface (`upsertPairingRequest` + `accountId`, `ChatType "direct"`, `ReplyDispatcher.getFailedCounts`/`markComplete`, typed `plugin-runtime` subpath).
- Fix two stale `src/integration.test.ts` cases that still expected HTTP 400 for empty-messages requests — handler has returned 200 (empty SSE run) since `e3a88c8` (AG-UI protocol compliance for init/sync).
- Patch bump to `0.6.4` (no new user-facing functionality), update CHANGELOG.

Commits are split so review stays scoped:

1. `3c17b0a` — SDK-compat fixes (`index.ts`, `src/http-handler.ts`, `src/http-handler.test.ts`).
2. `bd1b11a` — align integration tests with post-`e3a88c8` handler behavior.
3. `d460150` — version bump + CHANGELOG.

## Test plan

- [x] `pnpm build` — green against openclaw `2026.4.16`.
- [x] `pnpm test` (unit) — 70/70 passing.
- [x] `pnpm test src/integration.test.ts` against a live gateway (workspace openclaw `2026.4.16`, paired device) — 13/13 passing.
- [x] End-to-end curl probe of `/v1/clawg-ui`: full SSE sequence (`RUN_STARTED → TEXT_MESSAGE_START/CONTENT/END → RUN_FINISHED`) returned over the new `accountId="default"` pairing flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)