### PR TITLE
chore: gitignore pnpm-lock.yaml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 dist/
 *.tgz
+pnpm-lock.yaml


### PR DESCRIPTION
## Summary

Adds `pnpm-lock.yaml` to `.gitignore`.

## Why

clawg-ui is a published library, not an application:

- **Consumers don't see the lockfile** — they install from `package.json` ranges and resolve themselves, so a tracked lockfile doesn't change what end users get.
- **`openclaw: "file:../openclaw"` is non-portable** — pnpm encodes path-relative resolution under that key, which won't match other contributors' workspace layouts.
- **No CI enforces `--frozen-lockfile`** — without that, a tracked lockfile drifts silently and provides no guarantee anyway.
- **`@ag-ui/*` is in the 0.0.x range and moving** — Renovate/Dependabot churn against a tracked lockfile would dominate PR noise.

This rule prevents a stray `pnpm install` from bundling a 7000+ line lockfile into a future PR (which is what happened in the original PR #26 and was fixed during rebase).

## Follow-up

If/when CI is added that would benefit from a frozen install, revisit and remove this line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)